### PR TITLE
fix: use python3 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,15 +50,15 @@ test-coverage:
 # ============================================================================
 build:
 	@echo "Building distribution packages..."
-	python -m build
+	python3 -m build
 
 upload:
 	@echo "Uploading to PyPI..."
-	python -m twine upload dist/*
+	python3 -m twine upload dist/*
 
 upload-test:
 	@echo "Uploading to Test PyPI..."
-	python -m twine upload --repository testpypi dist/*
+	python3 -m twine upload --repository testpypi dist/*
 
 # ============================================================================
 # Documentation


### PR DESCRIPTION
## Summary
- Fix Makefile to use `python3` instead of `python` (which was permission-denied on some systems)

## Test plan
- [x] `make build` works with python3
- [x] All 42 tests passing, 95% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)