### PR TITLE
feat: add _skills/ with non-monolith skills layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ Documentation = "https://scitex-tunnel.readthedocs.io"
 [tool.hatch.build.targets.wheel]
 packages = ["src/scitex_tunnel"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"src/scitex_tunnel/_skills" = "scitex_tunnel/_skills"
+
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/scitex_tunnel/_skills/scitex-tunnel/SKILL.md
+++ b/src/scitex_tunnel/_skills/scitex-tunnel/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: scitex-tunnel
+description: Persistent SSH reverse tunnel for NAT traversal - auto-reconnecting tunnels for accessing machines behind firewalls. Use when setting up remote access to lab machines or HPC nodes.
+allowed-tools: mcp__scitex__tunnel_*
+---
+
+
+# SSH Tunnels with scitex-tunnel
+
+
+## Details
+
+- For quick start, see [quick-start.md](quick-start.md)
+- For python api, see [python-api.md](python-api.md)
+- For cli commands, see [cli-commands.md](cli-commands.md)
+- For environment variables, see [environment-variables.md](environment-variables.md)
+- For mcp tools (for ai agents), see [mcp-tools-for-ai-agents.md](mcp-tools-for-ai-agents.md)

--- a/src/scitex_tunnel/_skills/scitex-tunnel/cli-commands.md
+++ b/src/scitex_tunnel/_skills/scitex-tunnel/cli-commands.md
@@ -1,0 +1,17 @@
+## CLI Commands
+
+```bash
+# Core
+scitex-tunnel setup --port <port> --bastion <host> --secret-key <path>
+scitex-tunnel status [--port <port>]
+scitex-tunnel remove --port <port>
+
+# MCP server
+scitex-tunnel mcp start [--transport <str>] [--host <host>] [--port <port>]
+scitex-tunnel mcp doctor
+scitex-tunnel mcp list-tools
+scitex-tunnel mcp installation
+
+# Introspection
+scitex-tunnel list-python-apis [-v]
+```

--- a/src/scitex_tunnel/_skills/scitex-tunnel/environment-variables.md
+++ b/src/scitex_tunnel/_skills/scitex-tunnel/environment-variables.md
@@ -1,0 +1,6 @@
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `SCITEX_TUNNEL_BASTION_SERVER` | Default bastion server (if --bastion not provided) |
+| `SCITEX_TUNNEL_SECRET_KEY_PATH` | Default SSH key path (if --secret-key not provided) |

--- a/src/scitex_tunnel/_skills/scitex-tunnel/mcp-tools-for-ai-agents.md
+++ b/src/scitex_tunnel/_skills/scitex-tunnel/mcp-tools-for-ai-agents.md
@@ -1,0 +1,7 @@
+## MCP Tools (for AI agents)
+
+| Tool | Parameters | Purpose |
+|------|-----------|---------|
+| `tunnel_setup` | `port`, `bastion_server`, `secret_key_path` | Create persistent SSH tunnel |
+| `tunnel_status` | `port` (optional) | Check tunnel status |
+| `tunnel_remove` | `port` | Remove tunnel |

--- a/src/scitex_tunnel/_skills/scitex-tunnel/python-api.md
+++ b/src/scitex_tunnel/_skills/scitex-tunnel/python-api.md
@@ -1,0 +1,9 @@
+## Python API
+
+| Function | Signature | Purpose |
+|----------|-----------|---------|
+| `setup()` | `setup(port, bastion_server=None, secret_key_path=None) -> dict` | Create persistent SSH tunnel |
+| `status()` | `status(port=None) -> dict` | Check tunnel status (all or specific port) |
+| `remove()` | `remove(port) -> dict` | Remove tunnel by port |
+| `get_version()` | `get_version() -> str` | Get package version |
+| `AVAILABLE` | `bool` | Whether tunnel dependencies are available |

--- a/src/scitex_tunnel/_skills/scitex-tunnel/quick-start.md
+++ b/src/scitex_tunnel/_skills/scitex-tunnel/quick-start.md
@@ -1,0 +1,37 @@
+## Quick Start
+
+```bash
+# Setup a tunnel (port 22 exposed via bastion)
+scitex-tunnel setup --port 22 --bastion jump.example.com --secret-key ~/.ssh/id_rsa
+
+# Check status
+scitex-tunnel status
+
+# Check specific port
+scitex-tunnel status --port 22
+
+# Remove tunnel
+scitex-tunnel remove --port 22
+```
+
+```python
+from scitex_tunnel import setup, status, remove
+
+# Create tunnel
+result = setup(port=22, bastion_server="jump.example.com", secret_key_path="~/.ssh/id_rsa")
+# Returns: {"success": True, "stdout": "...", "stderr": "..."}
+
+# Check all tunnels
+result = status()
+
+# Check specific port
+result = status(port=22)
+
+# Remove tunnel
+result = remove(port=22)
+
+# Check availability
+from scitex_tunnel import AVAILABLE, get_version
+print(AVAILABLE)       # True/False
+print(get_version())   # "0.x.y"
+```


### PR DESCRIPTION
## Summary
- Add `_skills/<pkg>/` directory with non-monolith skills layout
- SKILL.md is index-only with links to focused sub-skill files
- Each sub-skill verified against actual source code
- pyproject.toml force-include for wheel bundling

## Test plan
- [ ] CI passes
- [ ] Skills files included in wheel

Generated with [Claude Code](https://claude.com/claude-code)