### PR TITLE
ci(quality): fix broken quality workflow (single-package audit-all)

### DIFF
--- a/.github/workflows/scitex-ssh-quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/scitex-ssh-quality-audit-on-ubuntu-latest.yml
@@ -1,8 +1,17 @@
 name: quality
 
-# Nightly ecosystem-wide static audit — catches regressions like the missing
-# scitex-config dep that broke 6 PyPI packages on 2026-04-28. Outputs a JSON
-# artifact and creates a GitHub issue if any CRITICAL/HIGH findings surface.
+# Single-package quality gate — runs `scitex-dev ecosystem audit-all`
+# against this package (audit-cli / audit-mcp-tools / audit-skills /
+# audit-python-apis / audit-project). Mirrors the canonical audit that
+# `tests/develop/test_audit.py` runs inside the test suite, but as a
+# standalone gate so an audit regression is visible even when the matrix
+# is skipped.
+#
+# The previous body of this workflow shallow-cloned the entire ecosystem
+# and ran `scripts/quality/audit_ecosystem.py` — both of which live only
+# in scitex-dev, not in leaf packages. That template was copied here
+# verbatim and was always broken (FileNotFoundError on a non-existent
+# ecosystem registry file). This version audits just this package.
 
 on:
   schedule:
@@ -11,130 +20,29 @@ on:
   push:
     branches: [develop]
     paths:
-      - "scripts/quality/audit_ecosystem.py"
-      - "src/scitex_ssh/_ecosystem/_core.py"
-      - "src/scitex_ssh/ecosystem.py"
-      - ".github/workflows/quality-audit.yml"
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/scitex-ssh-quality-audit-on-ubuntu-latest.yml"
+  pull_request:
+    branches: [main, develop]
 
 jobs:
   audit:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Checkout scitex-ssh
-        uses: actions/checkout@v4
-        with:
-          path: scitex-ssh
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Shallow-clone every ecosystem package
+      - name: Install package + audit tooling
         run: |
-          set -e
-          mkdir -p proj
-          python3 - <<'PY'
-          import json, re, subprocess, sys
-          from pathlib import Path
-          # 0.11.0 layout: ecosystem.py moved to _ecosystem/_core.py.
-          eco_new = Path("scitex-ssh/src/scitex_ssh/_ecosystem/_core.py")
-          eco_old = Path("scitex-ssh/src/scitex_ssh/ecosystem.py")
-          src = (eco_new if eco_new.is_file() else eco_old).read_text()
-          for m in re.finditer(
-              r'^\s*"([\w-]+)"\s*:\s*\{(.*?)\},?\s*$', src,
-              re.MULTILINE | re.DOTALL):
-              name, body = m.group(1), m.group(2)
-              g = re.search(r'"github_repo"\s*:\s*"([^"]+)"', body)
-              cat = re.search(r'"category"\s*:\s*"([^"]+)"', body)
-              category = cat.group(1) if cat else "library"
-              if category not in ("umbrella", "library", "external-lib"):
-                  continue
-              if not g:
-                  continue
-              dest = Path("proj") / name
-              if dest.exists():
-                  continue
-              print(f"clone {g.group(1)} -> {dest}")
-              r = subprocess.run(
-                  ["git", "clone", "--depth", "1", "--no-tags",
-                   f"https://github.com/{g.group(1)}.git", str(dest)],
-                  capture_output=True, text=True)
-              if r.returncode:
-                  print(f"  WARN: {r.stderr.strip()[:200]}", file=sys.stderr)
-          PY
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install "scitex-dev[cli-audit]"
 
-      - name: Run ecosystem audit
-        id: audit
-        run: |
-          python3 scitex-ssh/scripts/quality/audit_ecosystem.py \
-            --projects-root proj \
-            --scitex-ssh-root scitex-ssh \
-            --out audit.json
-          echo "json_path=$(pwd)/audit.json" >> "$GITHUB_OUTPUT"
-          # Surface summary in step output.
-          python3 - <<'PY'
-          import json
-          d = json.load(open("audit.json"))
-          s = d["summary"]
-          print(f"::notice ::Packages audited: {s['packages_audited']}")
-          print(f"::notice ::Findings by severity: {s['by_severity']}")
-          if s["by_severity"].get("CRITICAL", 0):
-              print(f"::error ::{s['by_severity']['CRITICAL']} CRITICAL findings — see audit.json")
-          if s["by_severity"].get("HIGH", 0):
-              print(f"::warning ::{s['by_severity']['HIGH']} HIGH findings — see audit.json")
-          PY
-        continue-on-error: true  # never block the workflow on findings
-
-      - name: Upload audit JSON
-        uses: actions/upload-artifact@v4
-        with:
-          name: ecosystem-audit
-          path: audit.json
-          retention-days: 30
-
-      - name: Open / update tracking issue on CRITICAL or HIGH
-        if: ${{ always() }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -e
-          counts=$(python3 -c "import json; d=json.load(open('audit.json')); s=d['summary']['by_severity']; print(s.get('CRITICAL',0), s.get('HIGH',0))")
-          read crit high <<< "$counts"
-          if [[ "$crit" -eq 0 && "$high" -eq 0 ]]; then
-            echo "No CRITICAL/HIGH; skipping issue."
-            exit 0
-          fi
-          # Build a markdown body listing offenders.
-          body=$(python3 - <<'PY'
-          import json
-          d = json.load(open("audit.json"))
-          out = ["# Ecosystem Quality Audit findings", ""]
-          out.append(f"Generated: {d['generated_at']}")
-          out.append(f"Packages: {d['summary']['packages_audited']}")
-          out.append(f"By severity: `{d['summary']['by_severity']}`")
-          out.append("")
-          for sev in ("CRITICAL", "HIGH"):
-              hits = [(p, f) for p in d["packages"] for f in p["findings"] if f["severity"] == sev]
-              if not hits:
-                  continue
-              out.append(f"## {sev}")
-              for p, f in hits:
-                  out.append(f"- **{p['package']}** §{f['section']} ({f['lens']}) — {f['message']}")
-                  if f.get("detail"):
-                      out.append(f"    - {f['detail']}")
-          print("\n".join(out))
-          PY
-          )
-          # Reuse a single rolling issue per day.
-          title="quality-audit: $(date -u +%Y-%m-%d) — CRITICAL=$crit HIGH=$high"
-          existing=$(gh issue list -R "$GITHUB_REPOSITORY" --label quality-audit --state open --json number,title \
-              | python3 -c "import sys,json; d=json.load(sys.stdin); print(next((x['number'] for x in d if x['title'].startswith('quality-audit:')), ''))")
-          if [[ -n "$existing" ]]; then
-            gh issue comment "$existing" -R "$GITHUB_REPOSITORY" --body "$body"
-            gh issue edit "$existing" -R "$GITHUB_REPOSITORY" --title "$title"
-          else
-            gh issue create -R "$GITHUB_REPOSITORY" --title "$title" --body "$body" \
-              --label quality-audit
-          fi
+      - name: Run scitex-dev ecosystem audit-all
+        run: scitex-dev ecosystem audit-all scitex-ssh --no-version-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `_allowlist`: honour the `$SCITEX_SSH_CONFIG` environment variable as a
+  config-path override (resolved per-call via the new `config_path()`),
+  matching the precedence chain already advertised in the CLI `--help` and
+  the skills docs. Closes a doc-vs-code gap.
+
+### Changed
+
+- Test suite de-mocked end to end (no `unittest.mock` / `patch` /
+  `MagicMock` / `monkeypatch`): ssh/scp/bash/systemctl collaborators are
+  exercised through real fake binaries on `$PATH`, the allowlist through a
+  real config file, env-var fallbacks through a save/restore fixture. Tests
+  now satisfy the test-quality rules (one assertion per test, AAA markers,
+  descriptive names). Shared `subprocess_shim` / `env_save_restore` /
+  `allow_tunnels` / `deny_tunnels` fixtures live in `tests/conftest.py`.
+
 ## [1.0.0]
 
 - Initial CHANGELOG entry — see git log for prior history.

--- a/src/scitex_ssh/_allowlist.py
+++ b/src/scitex_ssh/_allowlist.py
@@ -1,6 +1,7 @@
 """Per-host policy for gating sensitive features (currently: tunnels).
 
-Config file: ~/.scitex/ssh/config.yaml
+Config file resolution (first that exists wins):
+  $SCITEX_SSH_CONFIG  ->  ~/.scitex/ssh/config.yaml
 
 Schema:
   default:
@@ -10,20 +11,42 @@ Schema:
     nas:    {tunnels: allow}
     spartan: {tunnels: deny}
 
-If the file does not exist: default policy is `deny` (fail-closed).
+If no config file exists: default policy is `deny` (fail-closed).
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Literal
+
+#: Default config location. Overridable per-call via the $SCITEX_SSH_CONFIG
+#: environment variable (see `config_path()`), matching the precedence chain
+#: advertised in the CLI `--help`.
+CONFIG_PATH = Path.home() / ".scitex" / "ssh" / "config.yaml"
 
 
 class PolicyError(RuntimeError):
     """Raised when an action is denied by the allowlist."""
 
 
-CONFIG_PATH = Path.home() / ".scitex" / "ssh" / "config.yaml"
+def config_path() -> Path:
+    """Resolve the active config path.
+
+    `$SCITEX_SSH_CONFIG` takes precedence over the default
+    `~/.scitex/ssh/config.yaml`. Resolved at call time so the environment
+    can be set after import (and so tests can point at a tmp config).
+    """
+    env = os.environ.get("SCITEX_SSH_CONFIG")
+    if env:
+        return Path(env)
+    return CONFIG_PATH
+
+
+#: Module-level alias so functions whose keyword parameter is also named
+#: ``config_path`` (the explicit-override seam) can still reach the
+#: env-aware resolver without the parameter shadowing it.
+_resolve_config_path = config_path
 
 
 def is_allowed(
@@ -37,11 +60,13 @@ def is_allowed(
     Parameters
     ----------
     config_path : Path, optional
-        Override the config file location. Defaults to ``CONFIG_PATH``
-        (``~/.scitex/ssh/config.yaml``). Used by tests to point at a
-        real config in ``tmp_path`` without patching module globals.
+        Override the config file location. Defaults to the path resolved
+        by ``config_path()`` (``$SCITEX_SSH_CONFIG`` then
+        ``~/.scitex/ssh/config.yaml``). Used by tests to point at a real
+        config in ``tmp_path`` without patching module globals.
     """
-    cfg = _load(config_path if config_path is not None else CONFIG_PATH)
+    resolved = config_path if config_path is not None else _resolve_config_path()
+    cfg = _load(resolved)
     if cfg is None:
         return False  # fail-closed when no config
     hosts = cfg.get("hosts") or {}
@@ -59,7 +84,9 @@ def require(
     config_path: Path | None = None,
 ) -> None:
     if not is_allowed(host, feature, config_path=config_path):
-        path_for_msg = config_path if config_path is not None else CONFIG_PATH
+        path_for_msg = (
+            config_path if config_path is not None else _resolve_config_path()
+        )
         raise PolicyError(
             f"feature {feature!r} is not allowed for host {host!r}. "
             f"Edit {path_for_msg} to add 'hosts.{host}.{feature}: allow' "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,26 +8,15 @@ Also wires subprocess coverage: see
 05_development_06_subprocess-coverage.md. `os.environ.setdefault`
 would be a no-op because pytest-cov has already set
 COVERAGE_FILE by the time conftest is loaded.
-
-Shared test fakes (no-mocks discipline — 02_package_12_no-mocks.md):
-- ``FakeRunner`` — hand-rolled ``subprocess.run`` stand-in that
-  records every call and returns a configurable
-  ``subprocess.CompletedProcess``. Replaces every
-  ``unittest.mock.patch('subprocess.run')`` idiom that previously
-  haunted the test tree.
-- ``env_save_restore`` — yield-based fixture that snapshots and
-  restores ``os.environ`` mutations across a test. Replaces
-  ``monkeypatch.setenv``.
 """
 
 from __future__ import annotations
 
+import json
 import os
-import subprocess
+import stat
 import sysconfig
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -61,67 +50,122 @@ def _ensure_subprocess_coverage_shim() -> None:
 _ensure_subprocess_coverage_shim()
 
 
-# ---------------------------------------------------------------------
-# Shared no-mocks fakes
-# ---------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Real-collaborator fixtures (no-mocks discipline — see 02_package_12_no-mocks.md)
+# ---------------------------------------------------------------------------
 
 
-@dataclass
-class FakeRunner:
-    """Hand-rolled stand-in for ``subprocess.run``.
+class _Shim:
+    """Handle to a directory of fake binaries that log their argv.
 
-    Records every call (positional ``cmd`` plus kwargs) so tests can
-    observe what production *actually* invoked, and returns a
-    configurable ``subprocess.CompletedProcess`` so tests can stage
-    success / failure paths. Real, honest, mock-free.
+    Each installed binary appends one JSON line per invocation to a
+    per-binary log file, so a test can assert on the *real* argv that
+    `subprocess.run` constructed — exercising the production codepath
+    end to end instead of patching `subprocess.run`.
     """
 
-    returncode: int = 0
-    stdout: str = ""
-    stderr: str = ""
-    side_effect: Exception | None = None
-    calls: list[tuple[list[str], dict[str, Any]]] = field(default_factory=list)
+    def __init__(self, bin_dir: Path):
+        self.bin_dir = bin_dir
 
-    def __call__(self, cmd, **kwargs) -> subprocess.CompletedProcess:
-        # Coerce cmd to a plain list so test assertions don't have to
-        # care whether production passed a tuple or a list.
-        self.calls.append((list(cmd), dict(kwargs)))
-        if self.side_effect is not None:
-            raise self.side_effect
-        return subprocess.CompletedProcess(
-            args=list(cmd),
-            returncode=self.returncode,
-            stdout=self.stdout,
-            stderr=self.stderr,
+    def install(
+        self, name: str, *, rc: int = 0, stdout: str = "", stderr: str = ""
+    ) -> None:
+        """Create an executable fake `name` that records argv and exits `rc`."""
+        log = self.bin_dir / f"{name}.log"
+        log.write_text("")
+        script = (
+            "#!/usr/bin/env python3\n"
+            "import json, sys\n"
+            f"log = {str(log)!r}\n"
+            "with open(log, 'a') as fh:\n"
+            "    fh.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+            f"sys.stdout.write({stdout!r})\n"
+            f"sys.stderr.write({stderr!r})\n"
+            f"sys.exit({int(rc)})\n"
         )
+        path = self.bin_dir / name
+        path.write_text(script)
+        path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
-    @property
-    def call_count(self) -> int:
-        return len(self.calls)
+    def argv(self, name: str) -> list[str]:
+        """Return argv (excluding binary name) of the last call to `name`."""
+        log = self.bin_dir / f"{name}.log"
+        lines = [ln for ln in log.read_text().splitlines() if ln.strip()]
+        if not lines:
+            raise AssertionError(f"shim {name!r} was never invoked")
+        return json.loads(lines[-1])
 
-    @property
-    def last_cmd(self) -> list[str]:
-        assert self.calls, "FakeRunner was never called"
-        return self.calls[-1][0]
+    def call_count(self, name: str) -> int:
+        log = self.bin_dir / f"{name}.log"
+        if not log.exists():
+            return 0
+        return len([ln for ln in log.read_text().splitlines() if ln.strip()])
 
 
 @pytest.fixture
-def fake_runner() -> FakeRunner:
-    """Per-test ``FakeRunner`` with a default success result."""
-    return FakeRunner()
+def subprocess_shim(tmp_path):
+    """Yield a `_Shim` whose `bin/` is prepended to `$PATH`.
+
+    Tests call `shim.install("ssh", stdout="hi")` then exercise the
+    production function; the real `subprocess.run(["ssh", ...])` resolves
+    to the fake, which logs argv. Assert via `shim.argv("ssh")`.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    saved_path = os.environ.get("PATH", "")
+    os.environ["PATH"] = f"{bin_dir}{os.pathsep}{saved_path}"
+    try:
+        yield _Shim(bin_dir)
+    finally:
+        os.environ["PATH"] = saved_path
+
+
+@pytest.fixture
+def allow_tunnels(tmp_path, env_save_restore):
+    """Write an allowlist config that permits tunnels for every host.
+
+    Points the allowlist at it via $SCITEX_SSH_CONFIG (the documented
+    override) so allowlist-gated CLI commands (setup/remove) pass the
+    `_require_allowed(...)` check against a real config file.
+    """
+    cfg = tmp_path / "allow_config.yaml"
+    cfg.write_text("default: {tunnels: allow}\n")
+    env_save_restore("SCITEX_SSH_CONFIG", str(cfg))
+    return cfg
+
+
+@pytest.fixture
+def deny_tunnels(tmp_path, env_save_restore):
+    """Write an allowlist config that denies tunnels for every host.
+
+    Used to exercise the real PolicyError path through the CLI without a
+    forced mock side effect.
+    """
+    cfg = tmp_path / "deny_config.yaml"
+    cfg.write_text("default: {tunnels: deny}\n")
+    env_save_restore("SCITEX_SSH_CONFIG", str(cfg))
+    return cfg
 
 
 @pytest.fixture
 def env_save_restore():
-    """Yield-based snapshot/restore of ``os.environ`` mutations.
+    """Yield a setter that mutates os.environ and restores it on teardown.
 
-    Replaces ``monkeypatch.setenv`` — tests mutate ``os.environ``
-    inside the ``with``-block and the original mapping is restored
-    on teardown, regardless of test outcome.
+    Replaces `monkeypatch.setenv(...)`: call `set("HOME", "/tmp")` inside
+    a test; the original value (or absence) is restored at teardown.
     """
-    saved = dict(os.environ)
+    saved: dict[str, str | None] = {}
+
+    def _set(key: str, value: str) -> None:
+        if key not in saved:
+            saved[key] = os.environ.get(key)
+        os.environ[key] = value
+
     try:
-        yield os.environ
+        yield _set
     finally:
-        os.environ.clear()
-        os.environ.update(saved)
+        for key, old in saved.items():
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -15,22 +15,21 @@ in its source tree. Two outcomes:
   test is SKIPPED via `pytest.importorskip`. The umbrella's CI
   (which installs every peer) catches cross-package renames.
 """
+
 import pytest
 
 # ===== AUTO-GENERATED: cross-package imports =====
 CROSS_PACKAGE_IMPORTS = [
-    'scitex_dev._cli._completion',
+    "scitex_dev._cli._completion",
 ]
 # ===== END AUTO-GENERATED =====
 
 
 @pytest.mark.parametrize("module_name", CROSS_PACKAGE_IMPORTS)
-def test_cross_package_import_returns_real_module_object(module_name):
-    """Importing scitex-ssh's declared cross-package dependency must
-    return a real module object (not None) — proves the rename-detector
-    actually exercised the import rather than silently skipping it."""
+def test_cross_package_import(module_name):
+    """Importing scitex-ssh's declared cross-package dependency must succeed."""
     # Arrange
     # Act
-    mod = pytest.importorskip(module_name)
-    # Assert
-    assert mod.__name__ == module_name
+    module = pytest.importorskip(module_name)
+    # Assert — the imported object is really that module, not a stub
+    assert module.__name__ == module_name

--- a/tests/integration/test_examples_runtime.py
+++ b/tests/integration/test_examples_runtime.py
@@ -3,11 +3,6 @@
 Lives in tests/integration/ (not tests/examples/) because it cross-cuts every
 example with a single glob; the per-example syntax-check smokes in
 tests/examples/ provide finer-grained PS303 coverage.
-
-Implementation note — TQ007 (one assert per test) splits the original
-combined "examples exist AND each example exits zero" check into two
-discrete tests: one for the discovery contract, one parametrized per
-example for the actual run.
 """
 
 import subprocess
@@ -19,20 +14,17 @@ import pytest
 EXAMPLES = sorted(Path(__file__).resolve().parents[2].joinpath("examples").glob("*.py"))
 
 
-def test_examples_directory_discovers_at_least_one_script() -> None:
-    """Catch the silent-empty failure mode where `examples/` is wiped or
-    misnamed: parametrized per-example tests below would all skip-silent."""
+def test_examples_directory_is_not_empty():
     # Arrange
+    examples = EXAMPLES
     # Act
-    discovered = list(EXAMPLES)
+    count = len(examples)
     # Assert
-    assert discovered, "No example scripts found under examples/"
+    assert count > 0, "No example scripts found under examples/"
 
 
 @pytest.mark.parametrize("example", EXAMPLES, ids=lambda p: p.name)
-def test_example_script_runs_with_zero_exit_code(example: Path, tmp_path: Path) -> None:
-    """Each example script must run to completion. Real subprocess against
-    the live interpreter — exit code is the load-bearing signal."""
+def test_example_runs_to_completion(example, tmp_path):
     # Arrange
     cmd = [sys.executable, str(example)]
     # Act

--- a/tests/integration/test_public_api.py
+++ b/tests/integration/test_public_api.py
@@ -2,316 +2,251 @@
 """Integration tests for scitex_ssh public API surface.
 
 Exercises the top-level functions exposed from scitex_ssh/__init__.py
-(setup/remove/status/version) end-to-end using the production ``runner``
-injection kwarg + a hand-rolled ``FakeRunner`` (see
-``tests/conftest.py``) — no ``unittest.mock``, no ``monkeypatch``.
+(setup/remove/status/version) end-to-end against real collaborators:
+a fake `bash`/`systemctl` on $PATH (subprocess_shim) and a real allowlist
+config (allow_tunnels via $SCITEX_SSH_CONFIG). No mocks.
 
-Lives in tests/integration/ (not tests/scitex_ssh/) because the
-package's public API is defined in __init__.py and there is no module
-basename to mirror — this is the canonical home for cross-module
-surface tests per scitex-dev audit-project §3 / PS302.
+Lives in tests/integration/ (not tests/scitex_ssh/) because the package's
+public API is defined in __init__.py and there is no module basename to
+mirror — this is the canonical home for cross-module surface tests per
+scitex-dev audit-project §3 / PS302.
 """
 
 from __future__ import annotations
 
 import os
-from pathlib import Path
 
 import pytest
 
 import scitex_ssh
 
 
-# ---------------------------------------------------------------------
-# Allowlist bypass fixture — write a real config.yaml in tmp_path and
-# point the production loader at it via the `config_path` kwarg the
-# bypass-aware helpers below thread through.
-# ---------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _isolate_tunnel_env(allow_tunnels):
+    """Allow tunnels via a real config and clear inherited bastion/key env.
 
-
-@pytest.fixture
-def allow_all_cfg(tmp_path: Path, env_save_restore) -> Path:
-    """Write a tmp config that allows tunnels globally and point the
-    production allowlist loader at it via ``$HOME``."""
-    home = tmp_path / "home"
-    cfg_dir = home / ".scitex" / "ssh"
-    cfg_dir.mkdir(parents=True)
-    cfg = cfg_dir / "config.yaml"
-    cfg.write_text("default: {tunnels: allow}\n")
-    # CONFIG_PATH is computed at import time from $HOME; re-point HOME
-    # and rebind the module-level path so ``_require_allowed`` finds it.
-    os.environ["HOME"] = str(home)
-    from scitex_ssh import _allowlist
-
-    _allowlist.CONFIG_PATH = cfg
-    return cfg
-
-
-# ---------------------------------------------------------------------
-# Version + availability surface (no subprocess involved)
-# ---------------------------------------------------------------------
+    `allow_tunnels` writes an allow-all config and points $SCITEX_SSH_CONFIG
+    at it. Inherited SCITEX_SSH_BASTION_SERVER / SCITEX_SSH_SECRET_KEY_PATH
+    from the developer's shell are stripped so tests control them explicitly.
+    """
+    saved = {
+        k: os.environ.pop(k, None)
+        for k in ("SCITEX_SSH_BASTION_SERVER", "SCITEX_SSH_SECRET_KEY_PATH")
+    }
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
 
 class TestVersion:
     """Version and availability tests."""
 
-    def test_module_exposes_version_dunder_attribute(self) -> None:
+    def test_version_attribute_is_present(self):
         # Arrange
         # Act
-        present = hasattr(scitex_ssh, "__version__")
         # Assert
-        assert present is True
+        assert hasattr(scitex_ssh, "__version__")
 
-    def test_version_dunder_is_string_type(self) -> None:
+    def test_version_attribute_is_a_string(self):
         # Arrange
         # Act
-        v = scitex_ssh.__version__
         # Assert
-        assert isinstance(v, str)
+        assert isinstance(scitex_ssh.__version__, str)
 
-    def test_version_string_splits_into_three_dotted_parts(self) -> None:
+    def test_version_has_three_dotted_parts(self):
         # Arrange
         # Act
         parts = scitex_ssh.__version__.split(".")
         # Assert
         assert len(parts) == 3
 
-    def test_version_string_parts_are_all_digits(self) -> None:
+    def test_version_parts_are_all_numeric(self):
         # Arrange
         # Act
         parts = scitex_ssh.__version__.split(".")
         # Assert
         assert all(p.isdigit() for p in parts)
 
-    def test_get_version_helper_returns_dunder_version(self) -> None:
+    def test_get_version_matches_dunder_version(self):
         # Arrange
         # Act
-        result = scitex_ssh.get_version()
         # Assert
-        assert result == scitex_ssh.__version__
+        assert scitex_ssh.get_version() == scitex_ssh.__version__
 
-    def test_available_module_flag_is_true(self) -> None:
+    def test_available_flag_is_true(self):
         # Arrange
         # Act
-        flag = scitex_ssh.AVAILABLE
         # Assert
-        assert flag is True
+        assert scitex_ssh.AVAILABLE is True
 
 
 class TestScriptsDir:
     """Script directory tests."""
 
-    def test_scripts_dir_is_an_existing_directory(self) -> None:
+    def test_scripts_dir_is_a_directory(self):
         # Arrange
         # Act
-        is_dir = os.path.isdir(scitex_ssh._SCRIPTS_DIR)
         # Assert
-        assert is_dir is True
+        assert os.path.isdir(scitex_ssh._SCRIPTS_DIR)
 
-    def test_scripts_dir_contains_setup_autossh_service_sh(self) -> None:
+    def test_setup_script_file_is_present(self):
         # Arrange
+        # Act
         path = os.path.join(scitex_ssh._SCRIPTS_DIR, "setup-autossh-service.sh")
-        # Act
-        is_file = os.path.isfile(path)
         # Assert
-        assert is_file is True
+        assert os.path.isfile(path)
 
-    def test_scripts_dir_contains_remove_autossh_service_sh(self) -> None:
+    def test_remove_script_file_is_present(self):
         # Arrange
-        path = os.path.join(scitex_ssh._SCRIPTS_DIR, "remove-autossh-service.sh")
         # Act
-        is_file = os.path.isfile(path)
+        path = os.path.join(scitex_ssh._SCRIPTS_DIR, "remove-autossh-service.sh")
         # Assert
-        assert is_file is True
-
-
-# ---------------------------------------------------------------------
-# setup() — uses the bundled bash script via _run_script(runner=...)
-# ---------------------------------------------------------------------
+        assert os.path.isfile(path)
 
 
 class TestSetup:
-    """Tests for setup() function."""
+    """Tests for setup() function — real bash script invocation."""
 
-    def test_setup_returns_success_true_when_runner_returncode_zero(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_setup_reports_success_on_zero_exit(self, subprocess_shim):
         # Arrange
-        fake_runner.returncode = 0
-        fake_runner.stdout = "OK"
+        subprocess_shim.install("bash", rc=0, stdout="OK")
         # Act
-        result = scitex_ssh.setup(
-            2222,
-            "user@bastion",
-            "/home/user/.ssh/id_rsa",
-            runner=fake_runner,
-        )
+        result = scitex_ssh.setup(2222, "user@bastion", "/home/user/.ssh/id_rsa")
         # Assert
         assert result["success"] is True
 
-    def test_setup_propagates_runner_stdout_into_result(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_setup_captures_script_stdout(self, subprocess_shim):
         # Arrange
-        fake_runner.returncode = 0
-        fake_runner.stdout = "OK"
+        subprocess_shim.install("bash", rc=0, stdout="OK")
         # Act
-        result = scitex_ssh.setup(
-            2222,
-            "user@bastion",
-            "/home/user/.ssh/id_rsa",
-            runner=fake_runner,
-        )
+        result = scitex_ssh.setup(2222, "user@bastion", "/home/user/.ssh/id_rsa")
         # Assert
         assert result["stdout"] == "OK"
 
-    def test_setup_propagates_runner_stderr_into_result(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_setup_captures_empty_stderr_on_success(self, subprocess_shim):
         # Arrange
-        fake_runner.returncode = 0
+        subprocess_shim.install("bash", rc=0, stdout="OK")
         # Act
-        result = scitex_ssh.setup(
-            2222,
-            "user@bastion",
-            "/home/user/.ssh/id_rsa",
-            runner=fake_runner,
-        )
+        result = scitex_ssh.setup(2222, "user@bastion", "/home/user/.ssh/id_rsa")
         # Assert
         assert result["stderr"] == ""
 
-    def test_setup_argv_includes_dash_p_port_flag(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_setup_passes_port_flag_to_script(self, subprocess_shim):
         # Arrange
+        subprocess_shim.install("bash", rc=0)
         # Act
-        scitex_ssh.setup(
-            5098, "admin@relay.example.com", "/tmp/key", runner=fake_runner
-        )
+        scitex_ssh.setup(5098, "admin@relay.example.com", "/tmp/key")
         # Assert
-        assert "-p" in fake_runner.last_cmd
+        assert "-p" in subprocess_shim.argv("bash")
 
-    def test_setup_argv_includes_port_number_string(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_setup_passes_port_value_to_script(self, subprocess_shim):
         # Arrange
+        subprocess_shim.install("bash", rc=0)
         # Act
-        scitex_ssh.setup(
-            5098, "admin@relay.example.com", "/tmp/key", runner=fake_runner
-        )
+        scitex_ssh.setup(5098, "admin@relay.example.com", "/tmp/key")
         # Assert
-        assert "5098" in fake_runner.last_cmd
+        assert "5098" in subprocess_shim.argv("bash")
 
-    def test_setup_argv_includes_dash_b_bastion_flag(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_setup_passes_bastion_flag_to_script(self, subprocess_shim):
         # Arrange
+        subprocess_shim.install("bash", rc=0)
         # Act
-        scitex_ssh.setup(
-            5098, "admin@relay.example.com", "/tmp/key", runner=fake_runner
-        )
+        scitex_ssh.setup(5098, "admin@relay.example.com", "/tmp/key")
         # Assert
-        assert "-b" in fake_runner.last_cmd
+        assert "-b" in subprocess_shim.argv("bash")
 
-    def test_setup_argv_includes_bastion_address(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_setup_passes_bastion_value_to_script(self, subprocess_shim):
         # Arrange
+        subprocess_shim.install("bash", rc=0)
         # Act
-        scitex_ssh.setup(
-            5098, "admin@relay.example.com", "/tmp/key", runner=fake_runner
-        )
+        scitex_ssh.setup(5098, "admin@relay.example.com", "/tmp/key")
         # Assert
-        assert "admin@relay.example.com" in fake_runner.last_cmd
+        assert "admin@relay.example.com" in subprocess_shim.argv("bash")
 
-    def test_setup_argv_includes_dash_s_secret_key_flag(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_setup_passes_secret_key_flag_to_script(self, subprocess_shim):
         # Arrange
+        subprocess_shim.install("bash", rc=0)
         # Act
-        scitex_ssh.setup(
-            5098, "admin@relay.example.com", "/tmp/key", runner=fake_runner
-        )
+        scitex_ssh.setup(5098, "admin@relay.example.com", "/tmp/key")
         # Assert
-        assert "-s" in fake_runner.last_cmd
+        assert "-s" in subprocess_shim.argv("bash")
 
-    def test_setup_argv_includes_secret_key_path(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_setup_passes_secret_key_value_to_script(self, subprocess_shim):
         # Arrange
+        subprocess_shim.install("bash", rc=0)
         # Act
-        scitex_ssh.setup(
-            5098, "admin@relay.example.com", "/tmp/key", runner=fake_runner
-        )
+        scitex_ssh.setup(5098, "admin@relay.example.com", "/tmp/key")
         # Assert
-        assert "/tmp/key" in fake_runner.last_cmd
+        assert "/tmp/key" in subprocess_shim.argv("bash")
 
-    def test_setup_marks_nonzero_returncode_as_failure(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_setup_reports_failure_on_nonzero_exit(self, subprocess_shim):
         # Arrange
-        fake_runner.returncode = 1
-        fake_runner.stderr = "Permission denied"
+        subprocess_shim.install("bash", rc=1, stderr="Permission denied")
         # Act
-        result = scitex_ssh.setup(
-            2222, "user@bastion", "/tmp/key", runner=fake_runner
-        )
+        result = scitex_ssh.setup(2222, "user@bastion", "/tmp/key")
         # Assert
         assert result["success"] is False
 
-    def test_setup_failure_propagates_runner_stderr_into_result(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_setup_captures_script_stderr_on_failure(self, subprocess_shim):
         # Arrange
-        fake_runner.returncode = 1
-        fake_runner.stderr = "Permission denied"
+        subprocess_shim.install("bash", rc=1, stderr="Permission denied")
         # Act
-        result = scitex_ssh.setup(
-            2222, "user@bastion", "/tmp/key", runner=fake_runner
-        )
+        result = scitex_ssh.setup(2222, "user@bastion", "/tmp/key")
         # Assert
         assert result["stderr"] == "Permission denied"
 
-    def test_setup_env_fallback_uses_bastion_from_environment(
-        self, fake_runner, allow_all_cfg, env_save_restore
-    ) -> None:
+    def test_setup_uses_env_var_bastion_when_arg_omitted(
+        self, subprocess_shim, env_save_restore
+    ):
         # Arrange
-        os.environ["SCITEX_SSH_BASTION_SERVER"] = "env@bastion"
-        os.environ["SCITEX_SSH_SECRET_KEY_PATH"] = "/env/key"
+        subprocess_shim.install("bash", rc=0, stdout="OK")
+        env_save_restore("SCITEX_SSH_BASTION_SERVER", "env@bastion")
+        env_save_restore("SCITEX_SSH_SECRET_KEY_PATH", "/env/key")
         # Act
-        scitex_ssh.setup(2222, runner=fake_runner)
+        scitex_ssh.setup(2222)
         # Assert
-        assert "env@bastion" in fake_runner.last_cmd
+        assert "env@bastion" in subprocess_shim.argv("bash")
 
-    def test_setup_env_fallback_uses_secret_key_from_environment(
-        self, fake_runner, allow_all_cfg, env_save_restore
-    ) -> None:
+    def test_setup_uses_env_var_secret_key_when_arg_omitted(
+        self, subprocess_shim, env_save_restore
+    ):
         # Arrange
-        os.environ["SCITEX_SSH_BASTION_SERVER"] = "env@bastion"
-        os.environ["SCITEX_SSH_SECRET_KEY_PATH"] = "/env/key"
+        subprocess_shim.install("bash", rc=0, stdout="OK")
+        env_save_restore("SCITEX_SSH_BASTION_SERVER", "env@bastion")
+        env_save_restore("SCITEX_SSH_SECRET_KEY_PATH", "/env/key")
         # Act
-        scitex_ssh.setup(2222, runner=fake_runner)
+        scitex_ssh.setup(2222)
         # Assert
-        assert "/env/key" in fake_runner.last_cmd
+        assert "/env/key" in subprocess_shim.argv("bash")
 
-    def test_setup_raises_valueerror_when_bastion_missing_everywhere(
-        self, env_save_restore
-    ) -> None:
+    def test_setup_with_env_var_fallback_reports_success(
+        self, subprocess_shim, env_save_restore
+    ):
         # Arrange
-        os.environ.pop("SCITEX_SSH_BASTION_SERVER", None)
-        os.environ.pop("SCITEX_SSH_SECRET_KEY_PATH", None)
+        subprocess_shim.install("bash", rc=0, stdout="OK")
+        env_save_restore("SCITEX_SSH_BASTION_SERVER", "env@bastion")
+        env_save_restore("SCITEX_SSH_SECRET_KEY_PATH", "/env/key")
+        # Act
+        result = scitex_ssh.setup(2222)
+        # Assert
+        assert result["success"] is True
+
+    def test_setup_raises_when_bastion_missing(self):
+        # Arrange — _isolate_tunnel_env cleared the env vars
         # Act
         ctx = pytest.raises(ValueError, match="bastion_server is required")
         # Assert
         with ctx:
             scitex_ssh.setup(2222)
 
-    def test_setup_raises_valueerror_when_secret_key_missing_everywhere(
-        self, env_save_restore
-    ) -> None:
-        # Arrange
-        os.environ.pop("SCITEX_SSH_SECRET_KEY_PATH", None)
-        os.environ["SCITEX_SSH_BASTION_SERVER"] = "env@bastion"
+    def test_setup_raises_when_secret_key_missing(self, env_save_restore):
+        # Arrange — bastion present, secret key absent
+        env_save_restore("SCITEX_SSH_BASTION_SERVER", "env@bastion")
         # Act
         ctx = pytest.raises(ValueError, match="secret_key_path is required")
         # Assert
@@ -319,89 +254,68 @@ class TestSetup:
             scitex_ssh.setup(2222)
 
 
-# ---------------------------------------------------------------------
-# remove()
-# ---------------------------------------------------------------------
-
-
 class TestRemove:
-    """Tests for remove() function."""
+    """Tests for remove() function — real bash script invocation."""
 
-    def test_remove_marks_zero_returncode_as_success(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_remove_reports_success_on_zero_exit(self, subprocess_shim):
         # Arrange
-        fake_runner.returncode = 0
-        fake_runner.stdout = "Removed"
+        subprocess_shim.install("bash", rc=0, stdout="Removed")
         # Act
-        result = scitex_ssh.remove(2222, runner=fake_runner)
+        result = scitex_ssh.remove(2222)
         # Assert
         assert result["success"] is True
 
-    def test_remove_argv_includes_dash_p_port_flag(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_remove_passes_port_flag_to_script(self, subprocess_shim):
         # Arrange
+        subprocess_shim.install("bash", rc=0)
         # Act
-        scitex_ssh.remove(5098, runner=fake_runner)
+        scitex_ssh.remove(5098)
         # Assert
-        assert "-p" in fake_runner.last_cmd
+        assert "-p" in subprocess_shim.argv("bash")
 
-    def test_remove_argv_includes_port_number_string(
-        self, fake_runner, allow_all_cfg
-    ) -> None:
+    def test_remove_passes_port_value_to_script(self, subprocess_shim):
         # Arrange
+        subprocess_shim.install("bash", rc=0)
         # Act
-        scitex_ssh.remove(5098, runner=fake_runner)
+        scitex_ssh.remove(5098)
         # Assert
-        assert "5098" in fake_runner.last_cmd
-
-
-# ---------------------------------------------------------------------
-# status()
-# ---------------------------------------------------------------------
+        assert "5098" in subprocess_shim.argv("bash")
 
 
 class TestStatus:
-    """Tests for status() function."""
+    """Tests for status() function — real systemctl invocation."""
 
-    def test_status_all_marks_zero_returncode_as_success(self, fake_runner) -> None:
+    def test_status_all_reports_success(self, subprocess_shim):
         # Arrange
-        fake_runner.returncode = 0
-        fake_runner.stdout = "active"
+        subprocess_shim.install("systemctl", rc=0, stdout="active")
         # Act
-        result = scitex_ssh.status(runner=fake_runner)
+        result = scitex_ssh.status()
         # Assert
         assert result["success"] is True
 
-    def test_status_all_invokes_systemctl_list_units(self, fake_runner) -> None:
+    def test_status_all_uses_list_units(self, subprocess_shim):
         # Arrange
-        fake_runner.returncode = 0
+        subprocess_shim.install("systemctl", rc=0, stdout="active")
         # Act
-        scitex_ssh.status(runner=fake_runner)
+        scitex_ssh.status()
         # Assert
-        assert "list-units" in fake_runner.last_cmd
+        assert "list-units" in subprocess_shim.argv("systemctl")
 
-    def test_status_specific_port_marks_zero_returncode_as_success(
-        self, fake_runner
-    ) -> None:
+    def test_status_specific_port_reports_success(self, subprocess_shim):
         # Arrange
-        fake_runner.returncode = 0
-        fake_runner.stdout = "active"
+        subprocess_shim.install("systemctl", rc=0, stdout="active")
         # Act
-        result = scitex_ssh.status(port=2222, runner=fake_runner)
+        result = scitex_ssh.status(port=2222)
         # Assert
         assert result["success"] is True
 
-    def test_status_specific_port_targets_named_service_unit(
-        self, fake_runner
-    ) -> None:
+    def test_status_specific_port_targets_that_unit(self, subprocess_shim):
         # Arrange
-        fake_runner.returncode = 0
+        subprocess_shim.install("systemctl", rc=0, stdout="active")
         # Act
-        scitex_ssh.status(port=2222, runner=fake_runner)
+        scitex_ssh.status(port=2222)
         # Assert
-        assert "autossh-tunnel-2222.service" in fake_runner.last_cmd
+        assert "autossh-tunnel-2222.service" in subprocess_shim.argv("systemctl")
 
 
 # EOF

--- a/tests/scitex_ssh/_cli/test__introspect.py
+++ b/tests/scitex_ssh/_cli/test__introspect.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Tests for scitex_ssh._cli._introspect — `list-python-apis` command.
 
-All tests run real Click invocations against a live CliRunner — no
-mocks. Multi-assert variants from the prior file are collapsed via a
-shared ``json_payload`` fixture so each test stays single-assert
-(TQ007).
+No mocks. Each test runs the real Click command and asserts one thing.
+Shared invocations are lifted into fixtures so every test stays
+single-assertion.
 """
 
 from __future__ import annotations
@@ -18,21 +17,15 @@ from scitex_ssh._cli._introspect import list_python_apis
 
 
 @pytest.fixture
-def json_payload() -> dict:
-    """Parsed JSON payload from `list-python-apis --json`."""
-    runner = CliRunner()
-    result = runner.invoke(list_python_apis, ["--json"])
+def json_payload():
+    """Invoke `list-python-apis --json` once and return the parsed payload."""
+    result = CliRunner().invoke(list_python_apis, ["--json"])
     assert result.exit_code == 0, result.output
     return json.loads(result.output)
 
 
-# ---------------------------------------------------------------------
-# Default (text) output
-# ---------------------------------------------------------------------
-
-
-class TestListPythonApisDefault:
-    def test_default_invocation_exit_code_zero(self) -> None:
+class TestListPythonApis:
+    def test_default_invocation_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -40,23 +33,18 @@ class TestListPythonApisDefault:
         # Assert
         assert result.exit_code == 0
 
-    def test_default_output_lists_all_expected_public_function_names(self) -> None:
+    def test_default_lists_public_function_names(self):
         # Arrange
         runner = CliRunner()
-        expected = ("setup", "remove", "status", "get_version")
         # Act
         result = runner.invoke(list_python_apis, [])
         # Assert
-        assert all(name in result.output for name in expected)
+        assert all(
+            name in result.output
+            for name in ("setup", "remove", "status", "get_version")
+        )
 
-
-# ---------------------------------------------------------------------
-# Verbose (-v) output — includes module constants
-# ---------------------------------------------------------------------
-
-
-class TestListPythonApisVerbose:
-    def test_verbose_invocation_exit_code_zero(self) -> None:
+    def test_verbose_invocation_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -64,7 +52,7 @@ class TestListPythonApisVerbose:
         # Assert
         assert result.exit_code == 0
 
-    def test_verbose_output_lists_available_constant_name(self) -> None:
+    def test_verbose_includes_available_constant(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -72,7 +60,7 @@ class TestListPythonApisVerbose:
         # Assert
         assert "AVAILABLE" in result.output
 
-    def test_verbose_output_lists_version_dunder_constant_name(self) -> None:
+    def test_verbose_includes_version_constant(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -80,14 +68,7 @@ class TestListPythonApisVerbose:
         # Assert
         assert "__version__" in result.output
 
-
-# ---------------------------------------------------------------------
-# Very-verbose (-vv) output — pulls docstrings
-# ---------------------------------------------------------------------
-
-
-class TestListPythonApisVeryVerbose:
-    def test_very_verbose_invocation_exit_code_zero(self) -> None:
+    def test_very_verbose_invocation_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -95,7 +76,7 @@ class TestListPythonApisVeryVerbose:
         # Assert
         assert result.exit_code == 0
 
-    def test_very_verbose_output_includes_setup_docstring_lead(self) -> None:
+    def test_very_verbose_pulls_function_docstring(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -103,49 +84,29 @@ class TestListPythonApisVeryVerbose:
         # Assert
         assert "Set up a persistent SSH" in result.output
 
-
-# ---------------------------------------------------------------------
-# --json output — structured payload (uses json_payload fixture)
-# ---------------------------------------------------------------------
-
-
-class TestListPythonApisJson:
-    def test_json_invocation_exit_code_zero(self) -> None:
+    def test_json_payload_names_the_module(self, json_payload):
         # Arrange
-        runner = CliRunner()
+        payload = json_payload
         # Act
-        result = runner.invoke(list_python_apis, ["--json"])
-        # Assert
-        assert result.exit_code == 0
-
-    def test_json_payload_module_field_matches_canonical_import_name(
-        self, json_payload: dict
-    ) -> None:
-        # Arrange
-        # Act
-        module = json_payload["module"]
+        module = payload["module"]
         # Assert
         assert module == "scitex_ssh"
 
-    def test_json_payload_apis_includes_all_expected_public_function_names(
-        self, json_payload: dict
-    ) -> None:
+    def test_json_payload_lists_public_apis(self, json_payload):
         # Arrange
-        expected = {"setup", "remove", "status", "get_version"}
+        payload = json_payload
         # Act
-        api_names = {item["name"] for item in json_payload["apis"]}
+        api_names = {item["name"] for item in payload["apis"]}
         # Assert
-        assert expected.issubset(api_names)
+        assert {"setup", "remove", "status", "get_version"}.issubset(api_names)
 
-    def test_json_payload_constants_includes_available_and_version(
-        self, json_payload: dict
-    ) -> None:
+    def test_json_payload_lists_constants(self, json_payload):
         # Arrange
-        expected = {"AVAILABLE", "__version__"}
+        payload = json_payload
         # Act
-        const_names = {item["name"] for item in json_payload["constants"]}
+        const_names = {item["name"] for item in payload["constants"]}
         # Assert
-        assert expected.issubset(const_names)
+        assert {"AVAILABLE", "__version__"}.issubset(const_names)
 
 
 # EOF

--- a/tests/scitex_ssh/_cli/test__main.py
+++ b/tests/scitex_ssh/_cli/test__main.py
@@ -1,74 +1,37 @@
 #!/usr/bin/env python3
-"""Tests for scitex_ssh._cli._main.
+"""Tests for scitex_ssh._cli._main — top-level Click group, tunnel subgroup,
+deprecation aliases.
 
-Two layers, both mock-free:
-
-1. **CliRunner tests** — exercise the Click command tree end-to-end for
-   no-IO surfaces (--help, --version, --help-recursive, dry-run, sub-help).
-2. **Helper tests** — exercise `_do_tunnel_setup/_do_tunnel_remove/
-   _do_tunnel_status` directly with hand-rolled fake `setup_fn`/`remove_fn`/
-   `status_fn` callables that the production helpers accept as kwargs.
-   Bypasses Click for the success/failure/policy-error paths so we can
-   observe outcomes without patching `scitex_ssh.setup` etc.
+No mocks. Tunnel setup/remove/status run the real production functions
+against a fake `bash`/`systemctl` on $PATH (subprocess_shim) plus a real
+allowlist config (allow_tunnels). PolicyError is exercised with a real
+deny config rather than a forced side effect.
 """
 
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
-from typing import Any
 
-import pytest
 from click.testing import CliRunner
 
-from scitex_ssh._allowlist import PolicyError
 from scitex_ssh._cli._main import (
     CategorizedGroup,
     _default_host,
-    _do_tunnel_remove,
-    _do_tunnel_setup,
-    _do_tunnel_status,
     _get_version,
     main,
-    tunnel_status,
 )
-
-
-# ---------------------------------------------------------------------
-# Hand-rolled delegate fake — records args, returns staged dict or raises
-# ---------------------------------------------------------------------
-
-
-@dataclass
-class _FakeApiCall:
-    return_value: dict = field(
-        default_factory=lambda: {"success": True, "stdout": "", "stderr": ""}
-    )
-    side_effect: Exception | None = None
-    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = field(default_factory=list)
-
-    def __call__(self, *args, **kwargs) -> dict:
-        self.calls.append((args, dict(kwargs)))
-        if self.side_effect is not None:
-            raise self.side_effect
-        return dict(self.return_value)
-
-
-# ---------------------------------------------------------------------
-# Root group: --version / --help-recursive / no-arg / category headings
-# ---------------------------------------------------------------------
 
 
 class TestRootGroup:
     """Root `main` group: --version / --help-recursive / no-arg behavior."""
 
-    def test_main_object_is_categorized_group_instance(self) -> None:
+    def test_main_is_a_categorized_group(self):
         # Arrange
         # Act
         # Assert
         assert isinstance(main, CategorizedGroup)
 
-    def test_help_exit_code_zero_on_dash_dash_help(self) -> None:
+    def test_help_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -76,7 +39,7 @@ class TestRootGroup:
         # Assert
         assert result.exit_code == 0
 
-    def test_help_output_lists_ssh_primitives_category(self) -> None:
+    def test_help_lists_ssh_primitives_category(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -84,7 +47,7 @@ class TestRootGroup:
         # Assert
         assert "SSH Primitives" in result.output
 
-    def test_help_output_lists_tunnel_management_category(self) -> None:
+    def test_help_lists_tunnel_management_category(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -92,7 +55,7 @@ class TestRootGroup:
         # Assert
         assert "Tunnel Management" in result.output
 
-    def test_help_output_lists_integration_category(self) -> None:
+    def test_help_lists_integration_category(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -100,7 +63,7 @@ class TestRootGroup:
         # Assert
         assert "Integration" in result.output
 
-    def test_version_flag_exit_code_zero_on_dash_capital_v(self) -> None:
+    def test_version_flag_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -108,7 +71,7 @@ class TestRootGroup:
         # Assert
         assert result.exit_code == 0
 
-    def test_version_flag_output_contains_package_name(self) -> None:
+    def test_version_flag_prints_package_name(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -116,7 +79,7 @@ class TestRootGroup:
         # Assert
         assert "scitex-ssh" in result.output
 
-    def test_help_recursive_flag_exit_code_zero(self) -> None:
+    def test_help_recursive_flag_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -124,16 +87,18 @@ class TestRootGroup:
         # Assert
         assert result.exit_code == 0
 
-    def test_help_recursive_lists_every_top_level_subcommand(self) -> None:
+    def test_help_recursive_lists_every_top_level_command(self):
         # Arrange
         runner = CliRunner()
-        expected = ["exec", "copy", "attach", "tunnel", "mcp"]
         # Act
         result = runner.invoke(main, ["--help-recursive"])
         # Assert
-        assert all(tok in result.output for tok in expected)
+        assert all(
+            token in result.output
+            for token in ["exec", "copy", "attach", "tunnel", "mcp"]
+        )
 
-    def test_no_subcommand_exit_code_zero_for_bare_invocation(self) -> None:
+    def test_no_subcommand_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -141,7 +106,7 @@ class TestRootGroup:
         # Assert
         assert result.exit_code == 0
 
-    def test_no_subcommand_prints_usage_header(self) -> None:
+    def test_no_subcommand_prints_usage(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -150,15 +115,10 @@ class TestRootGroup:
         assert "Usage" in result.output
 
 
-# ---------------------------------------------------------------------
-# Tunnel subgroup help + dry-run (no subprocess)
-# ---------------------------------------------------------------------
+class TestTunnelSubgroup:
+    """`scitex-ssh tunnel {setup,remove,status}` — including --dry-run."""
 
-
-class TestTunnelSubgroupHelp:
-    """`scitex-ssh tunnel {setup,remove,status}` help + dry-run."""
-
-    def test_tunnel_help_exit_code_zero(self) -> None:
+    def test_tunnel_help_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -166,49 +126,45 @@ class TestTunnelSubgroupHelp:
         # Assert
         assert result.exit_code == 0
 
-    def test_tunnel_help_lists_all_tunnel_subcommands(self) -> None:
+    def test_tunnel_help_lists_subcommands(self):
         # Arrange
         runner = CliRunner()
-        expected = ("setup", "remove", "status")
         # Act
         result = runner.invoke(main, ["tunnel", "--help"])
         # Assert
-        assert all(sub in result.output for sub in expected)
+        assert all(sub in result.output for sub in ("setup", "remove", "status"))
 
-    def test_tunnel_setup_dry_run_exit_code_zero(self) -> None:
+    def test_tunnel_setup_dry_run_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
         result = runner.invoke(
-            main,
-            ["tunnel", "setup", "-p", "8080", "-b", "user@host", "--dry-run"],
+            main, ["tunnel", "setup", "-p", "8080", "-b", "user@host", "--dry-run"]
         )
         # Assert
         assert result.exit_code == 0
 
-    def test_tunnel_setup_dry_run_output_says_dry_run(self) -> None:
+    def test_tunnel_setup_dry_run_announces_dry_run(self):
         # Arrange
         runner = CliRunner()
         # Act
         result = runner.invoke(
-            main,
-            ["tunnel", "setup", "-p", "8080", "-b", "user@host", "--dry-run"],
+            main, ["tunnel", "setup", "-p", "8080", "-b", "user@host", "--dry-run"]
         )
         # Assert
         assert "DRY RUN" in result.output
 
-    def test_tunnel_setup_dry_run_output_includes_port(self) -> None:
+    def test_tunnel_setup_dry_run_mentions_port(self):
         # Arrange
         runner = CliRunner()
         # Act
         result = runner.invoke(
-            main,
-            ["tunnel", "setup", "-p", "8080", "-b", "user@host", "--dry-run"],
+            main, ["tunnel", "setup", "-p", "8080", "-b", "user@host", "--dry-run"]
         )
         # Assert
         assert "8080" in result.output
 
-    def test_tunnel_remove_dry_run_exit_code_zero(self) -> None:
+    def test_tunnel_remove_dry_run_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -216,7 +172,7 @@ class TestTunnelSubgroupHelp:
         # Assert
         assert result.exit_code == 0
 
-    def test_tunnel_remove_dry_run_output_says_dry_run(self) -> None:
+    def test_tunnel_remove_dry_run_announces_dry_run(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -224,242 +180,230 @@ class TestTunnelSubgroupHelp:
         # Assert
         assert "DRY RUN" in result.output
 
-
-# ---------------------------------------------------------------------
-# _do_tunnel_setup — direct tests with injected fake setup_fn
-# ---------------------------------------------------------------------
-
-
-class TestDoTunnelSetup:
-    def test_success_returns_normally_without_systemexit(self, capsys) -> None:
+    def test_tunnel_setup_success_exits_zero(self, subprocess_shim, allow_tunnels):
         # Arrange
-        fake = _FakeApiCall(
-            return_value={"success": True, "stdout": "service started", "stderr": ""}
+        subprocess_shim.install("bash", rc=0, stdout="service started")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(
+            main,
+            ["tunnel", "setup", "-p", "2222", "-b", "user@host", "-s", "/dev/null"],
         )
-        # Act
-        _do_tunnel_setup(2222, "user@host", "/dev/null", "myhost", setup_fn=fake)
         # Assert
-        assert "successfully" in capsys.readouterr().out
+        assert result.exit_code == 0
 
-    def test_success_invokes_setup_fn_with_supplied_positional_args(self) -> None:
+    def test_tunnel_setup_success_reports_success(self, subprocess_shim, allow_tunnels):
         # Arrange
-        fake = _FakeApiCall(
-            return_value={"success": True, "stdout": "", "stderr": ""}
+        subprocess_shim.install("bash", rc=0, stdout="service started")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(
+            main,
+            ["tunnel", "setup", "-p", "2222", "-b", "user@host", "-s", "/dev/null"],
         )
-        # Act
-        _do_tunnel_setup(2222, "user@host", "/dev/null", "myhost", setup_fn=fake)
         # Assert
-        assert fake.calls[0][0] == (2222, "user@host", "/dev/null")
+        assert "successfully" in result.output
 
-    def test_failure_raises_systemexit_with_exit_code_one(self) -> None:
+    def test_tunnel_setup_nonzero_script_exit_fails(
+        self, subprocess_shim, allow_tunnels
+    ):
         # Arrange
-        fake = _FakeApiCall(
-            return_value={
-                "success": False,
-                "stdout": "",
-                "stderr": "permission denied",
-            }
+        subprocess_shim.install("bash", rc=1, stderr="permission denied")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(
+            main,
+            ["tunnel", "setup", "-p", "2222", "-b", "user@host", "-s", "/dev/null"],
         )
-        # Act
-        ctx = pytest.raises(SystemExit)
         # Assert
-        with ctx:
-            _do_tunnel_setup(2222, "user@host", "/dev/null", "myhost", setup_fn=fake)
+        assert result.exit_code != 0
 
-    def test_policy_error_raises_systemexit_with_exit_code_two(self) -> None:
-        # Arrange
-        fake = _FakeApiCall(side_effect=PolicyError("not on the allowlist"))
+    def test_tunnel_setup_denied_host_exits_two(self, deny_tunnels):
+        # Arrange — real allowlist config that denies tunnels for every host
+        runner = CliRunner()
         # Act
-        ctx = pytest.raises(SystemExit, match="2")
-        # Assert
-        with ctx:
-            _do_tunnel_setup(2222, "user@host", "/dev/null", "myhost", setup_fn=fake)
-
-    def test_policy_error_writes_message_to_stderr(self, capsys) -> None:
-        # Arrange
-        fake = _FakeApiCall(side_effect=PolicyError("not on the allowlist"))
-        # Act
-        try:
-            _do_tunnel_setup(2222, "user@host", "/dev/null", "myhost", setup_fn=fake)
-        except SystemExit:
-            pass
-        # Assert
-        assert "not on the allowlist" in capsys.readouterr().err
-
-    def test_value_error_raises_systemexit_with_exit_code_one(self) -> None:
-        # Arrange
-        fake = _FakeApiCall(side_effect=ValueError("bastion_server is required"))
-        # Act
-        ctx = pytest.raises(SystemExit, match="1")
-        # Assert
-        with ctx:
-            _do_tunnel_setup(2222, None, "/dev/null", "myhost", setup_fn=fake)
-
-
-# ---------------------------------------------------------------------
-# _do_tunnel_remove — direct tests with injected fake remove_fn
-# ---------------------------------------------------------------------
-
-
-class TestDoTunnelRemove:
-    def test_success_returns_normally_without_systemexit(self, capsys) -> None:
-        # Arrange
-        fake = _FakeApiCall(
-            return_value={"success": True, "stdout": "removed", "stderr": ""}
+        result = runner.invoke(
+            main,
+            ["tunnel", "setup", "-p", "2222", "-b", "user@host", "-s", "/dev/null"],
         )
-        # Act
-        _do_tunnel_remove(2222, "myhost", remove_fn=fake)
-        # Assert
-        assert "removed" in capsys.readouterr().out.lower()
+        # Assert — PolicyError → exit 2
+        assert result.exit_code == 2
 
-    def test_success_invokes_remove_fn_with_supplied_port(self) -> None:
-        # Arrange
-        fake = _FakeApiCall(
-            return_value={"success": True, "stdout": "", "stderr": ""}
-        )
-        # Act
-        _do_tunnel_remove(2222, "myhost", remove_fn=fake)
-        # Assert
-        assert fake.calls[0][0] == (2222,)
-
-
-# ---------------------------------------------------------------------
-# _do_tunnel_status — direct tests with injected fake status_fn
-# ---------------------------------------------------------------------
-
-
-class TestDoTunnelStatus:
-    def test_invocation_writes_status_stdout_to_terminal(self, capsys) -> None:
-        # Arrange
-        fake = _FakeApiCall(
-            return_value={"success": True, "stdout": "active tunnels", "stderr": ""}
-        )
-        # Act
-        _do_tunnel_status(None, status_fn=fake)
-        # Assert
-        assert "active tunnels" in capsys.readouterr().out
-
-
-# ---------------------------------------------------------------------
-# `tunnel check-status --json` — test the click command callback directly
-# with an injected fake on `scitex_ssh.status`. Calls the callback by
-# binding the JSON branch through the public API, which is callable
-# directly via `tunnel_status.callback(...)` once we point scitex_ssh.status
-# at our fake via the create_server-style pattern. Since the click command
-# imports `scitex_ssh` locally, we test the JSON formatting via a tiny
-# pure-function extraction.
-# ---------------------------------------------------------------------
-
-
-class TestTunnelCheckStatusJson:
-    """The --json output path of `tunnel check-status`.
-
-    We invoke `tunnel_status.callback` directly with a sentinel port and
-    rely on the fact that the JSON branch only formats fields it reads
-    from the dict returned by `scitex_ssh.status`. The CLI exit path is
-    exercised by the dry-run / help tests above; here we narrow to the
-    JSON serialisation contract.
-    """
-
-    def test_json_port_value_round_trips_through_payload(
-        self, fake_runner, capsys
-    ) -> None:
-        # Arrange — point scitex_ssh.status at our FakeRunner via its
-        # `runner` kwarg by invoking the underlying API directly.
-        import scitex_ssh
-
-        fake_runner.stdout = "active"
-        # Act
-        payload = {
-            "port": 8080,
-            **{
-                k: v
-                for k, v in scitex_ssh.status(port=8080, runner=fake_runner).items()
-                if k in ("stdout", "stderr")
-            },
-        }
-        # Assert
-        assert payload["port"] == 8080
-
-    def test_json_stdout_value_round_trips_through_payload(
-        self, fake_runner
-    ) -> None:
-        # Arrange
-        import scitex_ssh
-
-        fake_runner.stdout = "active"
-        # Act
-        status_result = scitex_ssh.status(port=8080, runner=fake_runner)
-        # Assert
-        assert status_result["stdout"] == "active"
-
-
-# ---------------------------------------------------------------------
-# Deprecated top-level aliases — help text still describes them
-# ---------------------------------------------------------------------
-
-
-class TestDeprecatedAliasesHelp:
-    def test_setup_tunnel_alias_help_marks_command_deprecated(self) -> None:
+    def test_tunnel_setup_denied_host_reports_policy_error(self, deny_tunnels):
         # Arrange
         runner = CliRunner()
         # Act
-        result = runner.invoke(main, ["setup-tunnel", "--help"])
+        result = runner.invoke(
+            main,
+            ["tunnel", "setup", "-p", "2222", "-b", "user@host", "-s", "/dev/null"],
+        )
         # Assert
-        assert "deprecated" in result.output.lower()
+        assert "not allowed" in result.output
 
-    def test_remove_tunnel_alias_help_marks_command_deprecated(self) -> None:
+    def test_tunnel_remove_success_exits_zero(self, subprocess_shim, allow_tunnels):
         # Arrange
+        subprocess_shim.install("bash", rc=0, stdout="removed")
         runner = CliRunner()
         # Act
-        result = runner.invoke(main, ["remove-tunnel", "--help"])
+        result = runner.invoke(main, ["tunnel", "remove", "-p", "2222"])
         # Assert
-        assert "deprecated" in result.output.lower()
+        assert result.exit_code == 0
 
-    def test_show_status_alias_help_marks_command_deprecated(self) -> None:
+    def test_tunnel_remove_success_reports_removed(
+        self, subprocess_shim, allow_tunnels
+    ):
         # Arrange
+        subprocess_shim.install("bash", rc=0, stdout="removed")
         runner = CliRunner()
         # Act
-        result = runner.invoke(main, ["show-status", "--help"])
+        result = runner.invoke(main, ["tunnel", "remove", "-p", "2222"])
         # Assert
-        assert "deprecated" in result.output.lower()
+        assert "removed" in result.output.lower()
+
+    def test_tunnel_status_exits_zero(self, subprocess_shim):
+        # Arrange — status is not allowlist-gated
+        subprocess_shim.install("systemctl", rc=0, stdout="active tunnels")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(main, ["tunnel", "check-status"])
+        # Assert
+        assert result.exit_code == 0
+
+    def test_tunnel_status_streams_systemctl_stdout(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("systemctl", rc=0, stdout="active tunnels")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(main, ["tunnel", "check-status"])
+        # Assert
+        assert "active tunnels" in result.output
+
+    def test_tunnel_status_json_exits_zero(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("systemctl", rc=0, stdout="active")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(main, ["tunnel", "check-status", "-p", "8080", "--json"])
+        # Assert
+        assert result.exit_code == 0
+
+    def test_tunnel_status_json_payload_carries_port(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("systemctl", rc=0, stdout="active")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(main, ["tunnel", "check-status", "-p", "8080", "--json"])
+        # Assert
+        assert json.loads(result.output)["port"] == 8080
+
+    def test_tunnel_status_json_payload_carries_stdout(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("systemctl", rc=0, stdout="active")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(main, ["tunnel", "check-status", "-p", "8080", "--json"])
+        # Assert
+        assert json.loads(result.output)["stdout"] == "active"
 
 
-# ---------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------
+class TestDeprecatedAliases:
+    """Hidden top-level aliases warn but still delegate correctly."""
+
+    def test_setup_tunnel_deprecated_exits_zero(self, subprocess_shim, allow_tunnels):
+        # Arrange
+        subprocess_shim.install("bash", rc=0, stdout="")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(
+            main,
+            ["setup-tunnel", "-p", "2222", "-b", "user@host", "-s", "/dev/null"],
+        )
+        # Assert
+        assert result.exit_code == 0
+
+    def test_setup_tunnel_deprecated_warns_deprecated(
+        self, subprocess_shim, allow_tunnels
+    ):
+        # Arrange
+        subprocess_shim.install("bash", rc=0, stdout="")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(
+            main,
+            ["setup-tunnel", "-p", "2222", "-b", "user@host", "-s", "/dev/null"],
+        )
+        # Assert
+        assert "deprecated" in result.output
+
+    def test_remove_tunnel_deprecated_exits_zero(self, subprocess_shim, allow_tunnels):
+        # Arrange
+        subprocess_shim.install("bash", rc=0, stdout="")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(main, ["remove-tunnel", "-p", "2222"])
+        # Assert
+        assert result.exit_code == 0
+
+    def test_remove_tunnel_deprecated_warns_deprecated(
+        self, subprocess_shim, allow_tunnels
+    ):
+        # Arrange
+        subprocess_shim.install("bash", rc=0, stdout="")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(main, ["remove-tunnel", "-p", "2222"])
+        # Assert
+        assert "deprecated" in result.output
+
+    def test_show_status_deprecated_exits_zero(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("systemctl", rc=0, stdout="ok")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(main, ["show-status"])
+        # Assert
+        assert result.exit_code == 0
+
+    def test_show_status_deprecated_warns_deprecated(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("systemctl", rc=0, stdout="ok")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(main, ["show-status"])
+        # Assert
+        assert "deprecated" in result.output
 
 
 class TestHelpers:
     """Internal helpers — _get_version, _default_host."""
 
-    def test_get_version_returns_string_type(self) -> None:
+    def test_get_version_returns_a_string(self):
         # Arrange
         # Act
-        v = _get_version()
+        version = _get_version()
         # Assert
-        assert isinstance(v, str)
+        assert isinstance(version, str)
 
-    def test_get_version_returns_non_empty_string(self) -> None:
+    def test_get_version_returns_a_nonempty_string(self):
         # Arrange
         # Act
-        v = _get_version()
+        version = _get_version()
         # Assert
-        assert v
+        assert version
 
-    def test_default_host_returns_string_type(self) -> None:
+    def test_default_host_returns_a_string(self):
         # Arrange
         # Act
-        h = _default_host()
+        host = _default_host()
         # Assert
-        assert isinstance(h, str)
+        assert isinstance(host, str)
 
-    def test_default_host_strips_dots_for_short_form(self) -> None:
+    def test_default_host_strips_domain_to_short_form(self):
         # Arrange
         # Act
-        h = _default_host()
+        host = _default_host()
         # Assert
-        assert "." not in h
+        assert "." not in host
 
 
 # EOF

--- a/tests/scitex_ssh/_cli/test__mcp.py
+++ b/tests/scitex_ssh/_cli/test__mcp.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Tests for scitex_ssh._cli._mcp — `mcp` subgroup CLI.
 
-All tests run real Click invocations against a live CliRunner — no
-mocks. Multi-assert variants are collapsed via shared fixtures that
-parse the JSON output once so each test stays single-assert (TQ007).
+No mocks. Each test runs the real Click command and asserts one thing;
+shared `--json` invocations are lifted into fixtures so every test stays
+single-assertion.
 """
 
 from __future__ import annotations
@@ -16,34 +16,24 @@ from click.testing import CliRunner
 from scitex_ssh._cli._mcp import mcp
 
 
-# ---------------------------------------------------------------------
-# Shared fixtures — parse JSON payloads once per test
-# ---------------------------------------------------------------------
-
-
 @pytest.fixture
-def show_installation_payload() -> dict:
-    runner = CliRunner()
-    result = runner.invoke(mcp, ["show-installation", "--json"])
+def install_payload():
+    """Parse `mcp show-installation --json` once."""
+    result = CliRunner().invoke(mcp, ["show-installation", "--json"])
     assert result.exit_code == 0, result.output
     return json.loads(result.output)
 
 
 @pytest.fixture
-def list_tools_payload() -> dict:
-    runner = CliRunner()
-    result = runner.invoke(mcp, ["list-tools", "--json"])
+def list_tools_payload():
+    """Parse `mcp list-tools --json` once."""
+    result = CliRunner().invoke(mcp, ["list-tools", "--json"])
     assert result.exit_code == 0, result.output
     return json.loads(result.output)
-
-
-# ---------------------------------------------------------------------
-# mcp --help — lists subcommands
-# ---------------------------------------------------------------------
 
 
 class TestMcpGroup:
-    def test_help_invocation_exit_code_zero(self) -> None:
+    def test_help_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -51,23 +41,20 @@ class TestMcpGroup:
         # Assert
         assert result.exit_code == 0
 
-    def test_help_lists_all_expected_subcommand_names(self) -> None:
+    def test_help_lists_all_subcommands(self):
         # Arrange
         runner = CliRunner()
-        expected = ("start", "doctor", "show-installation", "list-tools")
         # Act
         result = runner.invoke(mcp, ["--help"])
         # Assert
-        assert all(sub in result.output for sub in expected)
-
-
-# ---------------------------------------------------------------------
-# mcp start --dry-run
-# ---------------------------------------------------------------------
+        assert all(
+            sub in result.output
+            for sub in ("start", "doctor", "show-installation", "list-tools")
+        )
 
 
 class TestMcpStart:
-    def test_dry_run_invocation_exit_code_zero(self) -> None:
+    def test_dry_run_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -75,7 +62,7 @@ class TestMcpStart:
         # Assert
         assert result.exit_code == 0
 
-    def test_dry_run_output_says_dry_run(self) -> None:
+    def test_dry_run_announces_dry_run(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -84,23 +71,16 @@ class TestMcpStart:
         assert "DRY RUN" in result.output
 
 
-# ---------------------------------------------------------------------
-# mcp doctor
-# ---------------------------------------------------------------------
-
-
 class TestMcpDoctor:
-    def test_doctor_invocation_exit_code_zero_or_one(self) -> None:
+    def test_doctor_exits_zero_or_one(self):
         # Arrange
         runner = CliRunner()
         # Act
         result = runner.invoke(mcp, ["doctor"])
         # Assert
-        # 1 if optional deps (e.g. fastmcp) are missing — both are valid
-        # outcomes for "doctor reports dependency status".
         assert result.exit_code in (0, 1)
 
-    def test_doctor_output_mentions_fastmcp_dependency(self) -> None:
+    def test_doctor_mentions_fastmcp(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -108,7 +88,7 @@ class TestMcpDoctor:
         # Assert
         assert "fastmcp" in result.output
 
-    def test_doctor_output_mentions_autossh_dependency(self) -> None:
+    def test_doctor_mentions_autossh(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -117,13 +97,8 @@ class TestMcpDoctor:
         assert "autossh" in result.output
 
 
-# ---------------------------------------------------------------------
-# mcp show-installation — text + JSON
-# ---------------------------------------------------------------------
-
-
-class TestMcpShowInstallationText:
-    def test_text_invocation_exit_code_zero(self) -> None:
+class TestMcpShowInstallation:
+    def test_text_output_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -131,7 +106,7 @@ class TestMcpShowInstallationText:
         # Assert
         assert result.exit_code == 0
 
-    def test_text_output_includes_pip_install_command(self) -> None:
+    def test_text_output_shows_pip_install_command(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -139,7 +114,7 @@ class TestMcpShowInstallationText:
         # Assert
         assert "pip install scitex-ssh[mcp]" in result.output
 
-    def test_text_output_includes_mcpservers_config_block(self) -> None:
+    def test_text_output_shows_mcp_servers_block(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -147,9 +122,7 @@ class TestMcpShowInstallationText:
         # Assert
         assert "mcpServers" in result.output
 
-
-class TestMcpShowInstallationJson:
-    def test_json_invocation_exit_code_zero(self) -> None:
+    def test_json_output_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -157,32 +130,25 @@ class TestMcpShowInstallationJson:
         # Assert
         assert result.exit_code == 0
 
-    def test_json_payload_install_command_matches_expected(
-        self, show_installation_payload: dict
-    ) -> None:
+    def test_json_payload_carries_install_command(self, install_payload):
         # Arrange
+        payload = install_payload
         # Act
-        install_cmd = show_installation_payload["install_command"]
+        install_command = payload["install_command"]
         # Assert
-        assert install_cmd == "pip install scitex-ssh[mcp]"
+        assert install_command == "pip install scitex-ssh[mcp]"
 
-    def test_json_payload_config_mcpservers_includes_scitex_ssh(
-        self, show_installation_payload: dict
-    ) -> None:
+    def test_json_payload_registers_the_server(self, install_payload):
         # Arrange
+        payload = install_payload
         # Act
-        servers = show_installation_payload["config"]["mcpServers"]
+        servers = payload["config"]["mcpServers"]
         # Assert
         assert "scitex-ssh" in servers
 
 
-# ---------------------------------------------------------------------
-# mcp list-tools — text + JSON
-# ---------------------------------------------------------------------
-
-
 class TestMcpListTools:
-    def test_default_invocation_exit_code_zero(self) -> None:
+    def test_default_lists_tools_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -190,16 +156,18 @@ class TestMcpListTools:
         # Assert
         assert result.exit_code == 0
 
-    def test_default_output_lists_all_expected_tool_names(self) -> None:
+    def test_default_lists_all_tunnel_tool_names(self):
         # Arrange
         runner = CliRunner()
-        expected = ("tunnel_setup", "tunnel_status", "tunnel_remove")
         # Act
         result = runner.invoke(mcp, ["list-tools"])
         # Assert
-        assert all(tool in result.output for tool in expected)
+        assert all(
+            tool in result.output
+            for tool in ("tunnel_setup", "tunnel_status", "tunnel_remove")
+        )
 
-    def test_verbose_invocation_exit_code_zero(self) -> None:
+    def test_verbose_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -207,7 +175,7 @@ class TestMcpListTools:
         # Assert
         assert result.exit_code == 0
 
-    def test_verbose_output_includes_setup_description_lead(self) -> None:
+    def test_verbose_includes_tool_descriptions(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -215,7 +183,7 @@ class TestMcpListTools:
         # Assert
         assert "Set up" in result.output
 
-    def test_very_verbose_invocation_exit_code_zero(self) -> None:
+    def test_very_verbose_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -223,7 +191,7 @@ class TestMcpListTools:
         # Assert
         assert result.exit_code == 0
 
-    def test_very_verbose_output_includes_params_label(self) -> None:
+    def test_very_verbose_includes_params(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -231,7 +199,7 @@ class TestMcpListTools:
         # Assert
         assert "params:" in result.output
 
-    def test_json_invocation_exit_code_zero(self) -> None:
+    def test_json_output_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -239,33 +207,25 @@ class TestMcpListTools:
         # Assert
         assert result.exit_code == 0
 
-    def test_json_payload_total_field_counts_three_tools(
-        self, list_tools_payload: dict
-    ) -> None:
+    def test_json_payload_reports_three_tools(self, list_tools_payload):
         # Arrange
+        payload = list_tools_payload
         # Act
-        total = list_tools_payload["total"]
+        total = payload["total"]
         # Assert
         assert total == 3
 
-    def test_json_payload_tools_names_match_expected_set(
-        self, list_tools_payload: dict
-    ) -> None:
+    def test_json_payload_lists_the_three_tunnel_tools(self, list_tools_payload):
         # Arrange
-        expected = {"tunnel_setup", "tunnel_status", "tunnel_remove"}
+        payload = list_tools_payload
         # Act
-        names = {t["name"] for t in list_tools_payload["tools"]}
+        names = {t["name"] for t in payload["tools"]}
         # Assert
-        assert names == expected
-
-
-# ---------------------------------------------------------------------
-# Deprecated `installation` alias — error redirect to `show-installation`
-# ---------------------------------------------------------------------
+        assert {"tunnel_setup", "tunnel_status", "tunnel_remove"} == names
 
 
 class TestDeprecatedInstallationAlias:
-    def test_installation_alias_exit_code_two(self) -> None:
+    def test_installation_alias_exits_two(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -273,7 +233,7 @@ class TestDeprecatedInstallationAlias:
         # Assert
         assert result.exit_code == 2
 
-    def test_installation_alias_output_points_to_show_installation(self) -> None:
+    def test_installation_alias_redirects_to_show_installation(self):
         # Arrange
         runner = CliRunner()
         # Act

--- a/tests/scitex_ssh/_cli/test__primitives.py
+++ b/tests/scitex_ssh/_cli/test__primitives.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python3
 """Tests for scitex_ssh._cli._primitives — exec/copy/attach CLI commands.
 
-The CLI commands forward to ``scitex_ssh.exec_remote`` / ``copy_to`` /
-``copy_from`` / ``attach``. The underlying behaviour (argv shape,
-return-code propagation, ssh-opts handling) is covered against real
-fake subprocess runners in ``tests/scitex_ssh/test__primitives.py``.
-
-Here we narrow scope to what only the CLI layer adds: argument parsing,
-dry-run plan output, and HOST:PATH-vs-local split logic. The mock-only
-"@patch(scitex_ssh.exec_remote)" tests from the original file were
-exercising Click's own dispatch rather than any first-party behaviour —
-they're replaced with helper tests that observe the same end state.
+No mocks. Pure helpers are tested directly; exec/copy invoke the real
+`exec_remote`/`copy_to`/`copy_from` against a fake ssh/scp on $PATH
+(subprocess_shim); attach runs the real CLI as a subprocess so its
+`os.execvp` replaces the child, not pytest.
 """
 
 from __future__ import annotations
+
+import os
+import subprocess
+import sys
 
 from click.testing import CliRunner
 
@@ -26,84 +24,68 @@ from scitex_ssh._cli._primitives import (
 )
 
 
-# ---------------------------------------------------------------------
-# _split_opts — pure helper
-# ---------------------------------------------------------------------
-
-
 class TestSplitOpts:
-    def test_none_input_returns_empty_list(self) -> None:
+    def test_none_returns_empty_list(self):
         # Arrange
         # Act
         result = _split_opts(None)
         # Assert
         assert result == []
 
-    def test_empty_string_input_returns_empty_list(self) -> None:
+    def test_empty_string_returns_empty_list(self):
         # Arrange
         # Act
         result = _split_opts("")
         # Assert
         assert result == []
 
-    def test_shell_quoted_opts_split_into_individual_tokens(self) -> None:
+    def test_shell_quoted_string_splits_into_tokens(self):
         # Arrange
-        raw = "-A -o StrictHostKeyChecking=no"
         # Act
-        result = _split_opts(raw)
+        result = _split_opts("-A -o StrictHostKeyChecking=no")
         # Assert
         assert result == ["-A", "-o", "StrictHostKeyChecking=no"]
 
 
-# ---------------------------------------------------------------------
-# _split_host_path — pure helper
-# ---------------------------------------------------------------------
-
-
 class TestSplitHostPath:
-    def test_remote_host_path_splits_on_first_colon(self) -> None:
+    def test_remote_host_path_splits_into_host_and_path(self):
         # Arrange
         # Act
         result = _split_host_path("myhost:/tmp/file")
         # Assert
         assert result == ("myhost", "/tmp/file")
 
-    def test_absolute_local_path_returns_none_host(self) -> None:
+    def test_absolute_local_path_has_no_host(self):
         # Arrange
         # Act
         result = _split_host_path("/tmp/file")
         # Assert
         assert result == (None, "/tmp/file")
 
-    def test_relative_local_path_returns_none_host(self) -> None:
+    def test_relative_local_path_has_no_host(self):
         # Arrange
         # Act
         result = _split_host_path("./file")
         # Assert
         assert result == (None, "./file")
 
-    def test_bare_local_filename_returns_none_host(self) -> None:
-        # Arrange
+    def test_bare_local_filename_has_no_host(self):
+        # Arrange — no colon → local.
         # Act
         result = _split_host_path("file.txt")
         # Assert
         assert result == (None, "file.txt")
 
-    def test_host_token_with_slash_treated_as_local_path(self) -> None:
-        # Arrange
+    def test_host_containing_slash_is_treated_as_local(self):
+        # Arrange — a "host" with `/` is not a real host (fallback safety net).
         # Act
         result = _split_host_path("foo/bar:baz")
         # Assert
         assert result == (None, "foo/bar:baz")
 
 
-# ---------------------------------------------------------------------
-# exec_cmd — only the dry-run / CLI-arg-parse surface
-# ---------------------------------------------------------------------
-
-
-class TestExecCmdDryRun:
-    def test_dry_run_invocation_exit_code_zero(self) -> None:
+class TestExecCmd:
+    def test_dry_run_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -111,7 +93,7 @@ class TestExecCmdDryRun:
         # Assert
         assert result.exit_code == 0
 
-    def test_dry_run_output_says_dry_run(self) -> None:
+    def test_dry_run_output_announces_dry_run(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -119,7 +101,7 @@ class TestExecCmdDryRun:
         # Assert
         assert "DRY RUN" in result.output
 
-    def test_dry_run_output_echoes_target_host_in_plan(self) -> None:
+    def test_dry_run_output_names_the_host(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -127,14 +109,45 @@ class TestExecCmdDryRun:
         # Assert
         assert "myhost" in result.output
 
+    def test_exec_against_fake_ssh_exits_zero(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("ssh", rc=0, stdout="ok\n")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(exec_cmd, ["myhost", "uname -a"])
+        # Assert
+        assert result.exit_code == 0
 
-# ---------------------------------------------------------------------
-# copy_cmd — dry-run + invalid-shape error paths
-# ---------------------------------------------------------------------
+    def test_exec_streams_remote_stdout_to_output(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("ssh", rc=0, stdout="ok\n")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(exec_cmd, ["myhost", "uname -a"])
+        # Assert
+        assert "ok" in result.output
+
+    def test_exec_propagates_nonzero_returncode(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("ssh", rc=7, stderr="boom\n")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(exec_cmd, ["myhost", "false"])
+        # Assert
+        assert result.exit_code == 7
+
+    def test_exec_streams_remote_stderr_to_output(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("ssh", rc=7, stderr="boom\n")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(exec_cmd, ["myhost", "false"])
+        # Assert
+        assert "boom" in result.output
 
 
-class TestCopyCmdDryRun:
-    def test_dry_run_invocation_exit_code_zero(self) -> None:
+class TestCopyCmd:
+    def test_dry_run_exits_zero(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -144,7 +157,7 @@ class TestCopyCmdDryRun:
         # Assert
         assert result.exit_code == 0
 
-    def test_dry_run_output_says_dry_run(self) -> None:
+    def test_dry_run_output_announces_dry_run(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -154,9 +167,7 @@ class TestCopyCmdDryRun:
         # Assert
         assert "DRY RUN" in result.output
 
-
-class TestCopyCmdInvalidShape:
-    def test_local_to_local_exits_with_code_two(self) -> None:
+    def test_local_to_local_copy_exits_two(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -164,7 +175,7 @@ class TestCopyCmdInvalidShape:
         # Assert
         assert result.exit_code == 2
 
-    def test_local_to_local_writes_must_be_host_path_message(self) -> None:
+    def test_local_to_local_copy_reports_host_path_required(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -172,7 +183,7 @@ class TestCopyCmdInvalidShape:
         # Assert
         assert "must be HOST:PATH" in result.output
 
-    def test_remote_to_remote_exits_with_code_two(self) -> None:
+    def test_remote_to_remote_copy_exits_two(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -180,7 +191,7 @@ class TestCopyCmdInvalidShape:
         # Assert
         assert result.exit_code == 2
 
-    def test_remote_to_remote_writes_remote_to_remote_message(self) -> None:
+    def test_remote_to_remote_copy_reports_unsupported(self):
         # Arrange
         runner = CliRunner()
         # Act
@@ -188,31 +199,77 @@ class TestCopyCmdInvalidShape:
         # Assert
         assert "remote-to-remote" in result.output
 
-
-# ---------------------------------------------------------------------
-# attach_cmd — help-only smoke. The success path replaces the current
-# process via `os.execvp`, so it cannot be exercised from a test without
-# forking; the underlying argv construction is covered by
-# `tests/scitex_ssh/test__primitives.py` against a real runner fake.
-# ---------------------------------------------------------------------
-
-
-class TestAttachCmdHelp:
-    def test_attach_help_exit_code_zero(self) -> None:
+    def test_copy_to_remote_exits_zero(self, subprocess_shim):
         # Arrange
+        subprocess_shim.install("scp", rc=0)
         runner = CliRunner()
         # Act
-        result = runner.invoke(attach_cmd, ["--help"])
+        result = runner.invoke(copy_cmd, ["./local.txt", "myhost:/tmp/local.txt"])
         # Assert
         assert result.exit_code == 0
 
-    def test_attach_help_output_mentions_host_argument(self) -> None:
+    def test_copy_to_remote_invokes_scp_once(self, subprocess_shim):
         # Arrange
+        subprocess_shim.install("scp", rc=0)
         runner = CliRunner()
         # Act
-        result = runner.invoke(attach_cmd, ["--help"])
+        runner.invoke(copy_cmd, ["./local.txt", "myhost:/tmp/local.txt"])
         # Assert
-        assert "HOST" in result.output
+        assert subprocess_shim.call_count("scp") == 1
+
+    def test_copy_from_remote_exits_zero(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("scp", rc=0)
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(copy_cmd, ["myhost:/etc/hostname", "./hostname"])
+        # Assert
+        assert result.exit_code == 0
+
+    def test_copy_from_remote_builds_remote_source_argv(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("scp", rc=0)
+        runner = CliRunner()
+        # Act
+        runner.invoke(copy_cmd, ["myhost:/etc/hostname", "./hostname"])
+        # Assert
+        assert subprocess_shim.argv("scp") == ["myhost:/etc/hostname", "./hostname"]
+
+
+def _run_attach(host, *, bin_dir):
+    """Run `python -m scitex_ssh attach <host>` as a real subprocess.
+
+    attach() calls os.execvp(["ssh", "-t", host]) which replaces the
+    child process — running in-process via CliRunner would replace
+    pytest itself. A real subprocess with a fake `ssh` on $PATH lets the
+    execvp succeed against the fake and surfaces the fake's exit code.
+    """
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    return subprocess.run(
+        [sys.executable, "-m", "scitex_ssh", "attach", host],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestAttachCmd:
+    def test_attach_execs_into_ssh_and_returns_its_exit_code(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("ssh", rc=0)
+        # Act
+        proc = _run_attach("myhost", bin_dir=subprocess_shim.bin_dir)
+        # Assert
+        assert proc.returncode == 0
+
+    def test_attach_passes_host_to_ssh_argv(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("ssh", rc=0)
+        # Act
+        _run_attach("myhost", bin_dir=subprocess_shim.bin_dir)
+        # Assert
+        assert subprocess_shim.argv("ssh") == ["-t", "myhost"]
 
 
 # EOF

--- a/tests/scitex_ssh/_mcp/test__server.py
+++ b/tests/scitex_ssh/_mcp/test__server.py
@@ -1,42 +1,19 @@
 #!/usr/bin/env python3
 """Tests for MCP server tools.
 
-Uses ``create_server(setup_fn=..., status_fn=..., remove_fn=...)`` —
-production accepts injectable callables so we exercise the real
-``FastMCP`` tool wiring against hand-rolled fakes (no ``unittest.mock``).
+No mocks. Tool callables run the real `scitex_ssh.setup/status/remove`
+against a fake `bash`/`systemctl` on $PATH (subprocess_shim) and a real
+allowlist config (allow_tunnels). We assert on the real returned dict,
+not on "was the delegate called".
 """
 
-from __future__ import annotations
-
 import asyncio
-from dataclasses import dataclass, field
-from typing import Any
 
 import pytest
 
 pytest.importorskip("fastmcp")
 
 from scitex_ssh._mcp._server import create_server  # noqa: E402
-
-
-# ---------------------------------------------------------------------
-# Hand-rolled delegate fakes — record every call as a flat dict so tests
-# can assert on call shape and stage return values per case.
-# ---------------------------------------------------------------------
-
-
-@dataclass
-class _FakeDelegate:
-    """Records positional + keyword args from each call."""
-
-    return_value: dict = field(
-        default_factory=lambda: {"success": True, "stdout": "", "stderr": ""}
-    )
-    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = field(default_factory=list)
-
-    def __call__(self, *args, **kwargs) -> dict:
-        self.calls.append((args, dict(kwargs)))
-        return dict(self.return_value)
 
 
 def _get_tool_fn(server, name):
@@ -46,65 +23,41 @@ def _get_tool_fn(server, name):
     return tool.fn
 
 
-# ---------------------------------------------------------------------
-# create_server — bare construction surface
-# ---------------------------------------------------------------------
-
-
 class TestCreateServer:
     """MCP server creation tests."""
 
-    def test_create_server_returns_non_none_fastmcp_instance(self) -> None:
+    def test_create_server_returns_an_object(self):
         # Arrange
         # Act
         server = create_server()
         # Assert
         assert server is not None
 
-    def test_create_server_names_the_server_scitex_ssh(self) -> None:
+    def test_create_server_names_the_server_scitex_ssh(self):
         # Arrange
         # Act
         server = create_server()
         # Assert
         assert server.name == "scitex-ssh"
 
-    def test_create_server_registers_tunnel_setup_status_remove_tools(self) -> None:
+    def test_server_registers_the_three_tunnel_tools(self):
         # Arrange
         server = create_server()
-        expected = {"tunnel_setup", "tunnel_status", "tunnel_remove"}
         # Act
         names = {t.name for t in asyncio.run(server.list_tools())}
         # Assert
-        assert expected.issubset(names)
+        assert {"tunnel_setup", "tunnel_status", "tunnel_remove"}.issubset(names)
 
 
-# ---------------------------------------------------------------------
-# Tool delegation — verify each tool calls its injected callable with
-# the correct positional shape, and that the tool's return value is
-# threaded through.
-# ---------------------------------------------------------------------
+class TestMCPTools:
+    """MCP tool delegation tests — exercised against real collaborators."""
 
-
-class TestTunnelSetupTool:
-    def test_tunnel_setup_forwards_positional_args_to_setup_fn(self) -> None:
+    def test_tunnel_setup_returns_success_when_script_exits_zero(
+        self, subprocess_shim, allow_tunnels
+    ):
         # Arrange
-        fake_setup = _FakeDelegate(
-            return_value={"success": True, "stdout": "started", "stderr": ""}
-        )
-        server = create_server(setup_fn=fake_setup)
-        tool_fn = _get_tool_fn(server, "tunnel_setup")
-        # Act
-        tool_fn(port=2222, bastion_server="user@host", secret_key_path="/dev/null")
-        # Assert
-        assert fake_setup.calls[0][0] == (2222, "user@host", "/dev/null")
-
-    def test_tunnel_setup_returns_setup_fn_result_to_caller(self) -> None:
-        # Arrange
-        fake_setup = _FakeDelegate(
-            return_value={"success": True, "stdout": "started", "stderr": ""}
-        )
-        server = create_server(setup_fn=fake_setup)
-        tool_fn = _get_tool_fn(server, "tunnel_setup")
+        subprocess_shim.install("bash", rc=0, stdout="started")
+        tool_fn = _get_tool_fn(create_server(), "tunnel_setup")
         # Act
         result = tool_fn(
             port=2222, bastion_server="user@host", secret_key_path="/dev/null"
@@ -112,73 +65,80 @@ class TestTunnelSetupTool:
         # Assert
         assert result["success"] is True
 
-
-class TestTunnelStatusTool:
-    def test_tunnel_status_no_port_forwards_none_to_status_fn(self) -> None:
+    def test_tunnel_setup_propagates_script_stdout(
+        self, subprocess_shim, allow_tunnels
+    ):
         # Arrange
-        fake_status = _FakeDelegate(
-            return_value={"success": True, "stdout": "active", "stderr": ""}
-        )
-        server = create_server(status_fn=fake_status)
-        tool_fn = _get_tool_fn(server, "tunnel_status")
+        subprocess_shim.install("bash", rc=0, stdout="started")
+        tool_fn = _get_tool_fn(create_server(), "tunnel_setup")
         # Act
-        tool_fn(port=None)
-        # Assert
-        assert fake_status.calls[0][0] == (None,)
-
-    def test_tunnel_status_returns_status_fn_result_to_caller(self) -> None:
-        # Arrange
-        fake_status = _FakeDelegate(
-            return_value={"success": True, "stdout": "active", "stderr": ""}
+        result = tool_fn(
+            port=2222, bastion_server="user@host", secret_key_path="/dev/null"
         )
-        server = create_server(status_fn=fake_status)
-        tool_fn = _get_tool_fn(server, "tunnel_status")
+        # Assert
+        assert result["stdout"] == "started"
+
+    def test_tunnel_setup_reports_failure_when_script_exits_nonzero(
+        self, subprocess_shim, allow_tunnels
+    ):
+        # Arrange
+        subprocess_shim.install("bash", rc=1, stderr="boom")
+        tool_fn = _get_tool_fn(create_server(), "tunnel_setup")
+        # Act
+        result = tool_fn(
+            port=2222, bastion_server="user@host", secret_key_path="/dev/null"
+        )
+        # Assert
+        assert result["success"] is False
+
+    def test_tunnel_status_returns_success_for_all_tunnels(self, subprocess_shim):
+        # Arrange — status is not allowlist-gated
+        subprocess_shim.install("systemctl", rc=0, stdout="active")
+        tool_fn = _get_tool_fn(create_server(), "tunnel_status")
         # Act
         result = tool_fn(port=None)
         # Assert
         assert result["success"] is True
 
-    def test_tunnel_status_with_port_forwards_int_to_status_fn(self) -> None:
+    def test_tunnel_status_for_all_tunnels_runs_systemctl(self, subprocess_shim):
         # Arrange
-        fake_status = _FakeDelegate(
-            return_value={
-                "success": True,
-                "stdout": "port 2222 active",
-                "stderr": "",
-            }
-        )
-        server = create_server(status_fn=fake_status)
-        tool_fn = _get_tool_fn(server, "tunnel_status")
+        subprocess_shim.install("systemctl", rc=0, stdout="active")
+        tool_fn = _get_tool_fn(create_server(), "tunnel_status")
+        # Act
+        tool_fn(port=None)
+        # Assert
+        assert subprocess_shim.call_count("systemctl") == 1
+
+    def test_tunnel_status_for_specific_port_queries_that_unit(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("systemctl", rc=0, stdout="port 2222 active")
+        tool_fn = _get_tool_fn(create_server(), "tunnel_status")
         # Act
         tool_fn(port=2222)
         # Assert
-        assert fake_status.calls[0][0] == (2222,)
+        assert "autossh-tunnel-2222.service" in subprocess_shim.argv("systemctl")
 
-
-class TestTunnelRemoveTool:
-    def test_tunnel_remove_forwards_port_to_remove_fn(self) -> None:
+    def test_tunnel_remove_returns_success_when_script_exits_zero(
+        self, subprocess_shim, allow_tunnels
+    ):
         # Arrange
-        fake_remove = _FakeDelegate(
-            return_value={"success": True, "stdout": "removed", "stderr": ""}
-        )
-        server = create_server(remove_fn=fake_remove)
-        tool_fn = _get_tool_fn(server, "tunnel_remove")
-        # Act
-        tool_fn(port=2222)
-        # Assert
-        assert fake_remove.calls[0][0] == (2222,)
-
-    def test_tunnel_remove_returns_remove_fn_result_to_caller(self) -> None:
-        # Arrange
-        fake_remove = _FakeDelegate(
-            return_value={"success": True, "stdout": "removed", "stderr": ""}
-        )
-        server = create_server(remove_fn=fake_remove)
-        tool_fn = _get_tool_fn(server, "tunnel_remove")
+        subprocess_shim.install("bash", rc=0, stdout="removed")
+        tool_fn = _get_tool_fn(create_server(), "tunnel_remove")
         # Act
         result = tool_fn(port=2222)
         # Assert
         assert result["success"] is True
+
+    def test_tunnel_remove_propagates_script_stdout(
+        self, subprocess_shim, allow_tunnels
+    ):
+        # Arrange
+        subprocess_shim.install("bash", rc=0, stdout="removed")
+        tool_fn = _get_tool_fn(create_server(), "tunnel_remove")
+        # Act
+        result = tool_fn(port=2222)
+        # Assert
+        assert result["stdout"] == "removed"
 
 
 # EOF

--- a/tests/scitex_ssh/test__allowlist.py
+++ b/tests/scitex_ssh/test__allowlist.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
-"""Tests for scitex_ssh._allowlist — fail-closed per-host policy.
+"""Tests for scitex_ssh._allowlist — real config file via $SCITEX_SSH_CONFIG.
 
-Uses the production ``config_path`` injection kwarg + ``tmp_path`` so
-each test exercises the real YAML loader against a real file (no
-``monkeypatch.setattr`` on module globals).
+No mocks: each test writes a real YAML config to tmp_path and points the
+allowlist at it with the $SCITEX_SSH_CONFIG env var (the documented
+override). The production `_load()` reads that real file.
 """
 
 from __future__ import annotations
-
-from pathlib import Path
 
 import pytest
 
@@ -16,103 +14,105 @@ from scitex_ssh._allowlist import PolicyError, is_allowed, require
 
 
 @pytest.fixture
-def cfg_path(tmp_path: Path) -> Path:
-    """Return the on-disk config path for the test (file not yet written)."""
-    return tmp_path / "config.yaml"
+def cfg(tmp_path, env_save_restore):
+    """Point the allowlist at a tmp config; return its path (not yet written)."""
+    path = tmp_path / "config.yaml"
+    env_save_restore("SCITEX_SSH_CONFIG", str(path))
+    return path
 
 
-def test_missing_config_returns_false_for_any_host(cfg_path: Path) -> None:
-    # Arrange
-    # (cfg_path fixture deliberately does not write the file)
+def test_missing_config_file_does_not_exist(cfg):
+    # Arrange — fixture set the env var but wrote no file
     # Act
-    allowed = is_allowed("anyhost", "tunnels", config_path=cfg_path)
+    exists = cfg.exists()
+    # Assert
+    assert exists is False
+
+
+def test_missing_config_denies_unknown_host(cfg):
+    # Arrange — no config file written
+    # Act
+    allowed = is_allowed("anyhost", "tunnels")
     # Assert
     assert allowed is False
 
 
-def test_missing_config_raises_policyerror_on_require(cfg_path: Path) -> None:
-    # Arrange
-    # (cfg_path fixture deliberately does not write the file)
+def test_missing_config_require_raises_policyerror(cfg):
+    # Arrange — no config file written
     # Act
     ctx = pytest.raises(PolicyError)
     # Assert
     with ctx:
-        require("anyhost", "tunnels", config_path=cfg_path)
+        require("anyhost", "tunnels")
 
 
-def test_host_explicitly_allowed_returns_true(cfg_path: Path) -> None:
+def test_host_explicitly_allowed_is_allowed_returns_true(cfg):
     # Arrange
-    cfg_path.write_text(
-        "default: {tunnels: deny}\nhosts:\n  mba: {tunnels: allow}\n"
-    )
+    cfg.write_text("default: {tunnels: deny}\nhosts:\n  mba: {tunnels: allow}\n")
     # Act
-    allowed = is_allowed("mba", "tunnels", config_path=cfg_path)
+    allowed = is_allowed("mba", "tunnels")
     # Assert
     assert allowed is True
 
 
-def test_host_explicitly_allowed_does_not_raise_on_require(cfg_path: Path) -> None:
+def test_host_explicitly_allowed_require_does_not_raise(cfg):
     # Arrange
-    cfg_path.write_text(
-        "default: {tunnels: deny}\nhosts:\n  mba: {tunnels: allow}\n"
-    )
-    completed = False
+    cfg.write_text("default: {tunnels: deny}\nhosts:\n  mba: {tunnels: allow}\n")
+    raised = False
     # Act
-    require("mba", "tunnels", config_path=cfg_path)
-    completed = True
+    try:
+        require("mba", "tunnels")
+    except PolicyError:
+        raised = True
     # Assert
-    assert completed
+    assert raised is False
 
 
-def test_host_explicitly_denied_returns_false(cfg_path: Path) -> None:
+def test_host_explicitly_denied_is_allowed_returns_false(cfg):
     # Arrange
-    cfg_path.write_text(
-        "default: {tunnels: allow}\nhosts:\n  spartan: {tunnels: deny}\n"
-    )
+    cfg.write_text("default: {tunnels: allow}\nhosts:\n  spartan: {tunnels: deny}\n")
     # Act
-    allowed = is_allowed("spartan", "tunnels", config_path=cfg_path)
+    allowed = is_allowed("spartan", "tunnels")
     # Assert
     assert allowed is False
 
 
-def test_host_explicitly_denied_raises_policyerror_on_require(cfg_path: Path) -> None:
+def test_host_explicitly_denied_require_raises_policyerror(cfg):
     # Arrange
-    cfg_path.write_text(
-        "default: {tunnels: allow}\nhosts:\n  spartan: {tunnels: deny}\n"
-    )
+    cfg.write_text("default: {tunnels: allow}\nhosts:\n  spartan: {tunnels: deny}\n")
     # Act
     ctx = pytest.raises(PolicyError)
     # Assert
     with ctx:
-        require("spartan", "tunnels", config_path=cfg_path)
+        require("spartan", "tunnels")
 
 
-def test_default_allow_grants_unlisted_host(cfg_path: Path) -> None:
+def test_default_allow_permits_unlisted_host(cfg):
     # Arrange
-    cfg_path.write_text("default: {tunnels: allow}\n")
+    cfg.write_text("default: {tunnels: allow}\n")
     # Act
-    allowed = is_allowed("randomhost", "tunnels", config_path=cfg_path)
+    allowed = is_allowed("randomhost", "tunnels")
     # Assert
     assert allowed is True
 
 
-def test_default_deny_blocks_unlisted_host(cfg_path: Path) -> None:
+def test_default_deny_denies_unlisted_host(cfg):
     # Arrange
-    cfg_path.write_text("default: {tunnels: deny}\n")
+    cfg.write_text("default: {tunnels: deny}\n")
     # Act
-    allowed = is_allowed("randomhost", "tunnels", config_path=cfg_path)
+    allowed = is_allowed("randomhost", "tunnels")
     # Assert
     assert allowed is False
 
 
-def test_default_deny_raises_policyerror_for_unlisted_host(cfg_path: Path) -> None:
+def test_default_deny_require_raises_policyerror_for_unlisted_host(cfg):
     # Arrange
-    cfg_path.write_text("default: {tunnels: deny}\n")
+    cfg.write_text("default: {tunnels: deny}\n")
     # Act
     ctx = pytest.raises(PolicyError)
     # Assert
     with ctx:
-        require("randomhost", "tunnels", config_path=cfg_path)
+        require("randomhost", "tunnels")
 
 
 # EOF

--- a/tests/scitex_ssh/test__primitives.py
+++ b/tests/scitex_ssh/test__primitives.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Tests for scitex_ssh._primitives — exec_remote / copy_to / copy_from.
+"""Tests for scitex_ssh._primitives — real ssh/scp argv via subprocess shim.
 
-Uses the production ``runner`` injection kwarg with a hand-rolled
-``FakeRunner`` (from ``tests/conftest.py``) so each test exercises the
-real production codepath without ``unittest.mock``.
+These exercise the production `subprocess.run(["ssh"/"scp", ...])` codepath
+end to end: a fake `ssh`/`scp` on `$PATH` records the argv the production
+code built, and we assert on it. No mocks — if the argv shape changes, the
+test fails honestly.
 """
 
 from __future__ import annotations
@@ -13,88 +14,80 @@ import pytest
 from scitex_ssh import SSHResult, copy_from, copy_to, exec_remote
 
 
-# ---------------------------------------------------------------------
-# exec_remote
-# ---------------------------------------------------------------------
-
-
-def test_exec_remote_basic_command_invokes_ssh_with_host_and_command(fake_runner):
+def test_exec_remote_builds_plain_ssh_argv_from_host_and_command(subprocess_shim):
     # Arrange
-    fake_runner.stdout = "hi"
+    subprocess_shim.install("ssh", rc=0, stdout="hi")
     # Act
-    exec_remote("spartan", "hostname", runner=fake_runner)
+    exec_remote("spartan", "hostname")
     # Assert
-    assert fake_runner.last_cmd == ["ssh", "spartan", "hostname"]
+    assert subprocess_shim.argv("ssh") == ["spartan", "hostname"]
 
 
-def test_exec_remote_basic_command_returns_sshresult_instance(fake_runner):
+def test_exec_remote_returns_sshresult_instance(subprocess_shim):
     # Arrange
-    fake_runner.stdout = "hi"
+    subprocess_shim.install("ssh", rc=0, stdout="hi")
     # Act
-    result = exec_remote("spartan", "hostname", runner=fake_runner)
+    result = exec_remote("spartan", "hostname")
     # Assert
     assert isinstance(result, SSHResult)
 
 
-def test_exec_remote_basic_command_propagates_stdout_into_result(fake_runner):
+def test_exec_remote_marks_zero_exit_as_success(subprocess_shim):
     # Arrange
-    fake_runner.stdout = "hi"
+    subprocess_shim.install("ssh", rc=0, stdout="hi")
     # Act
-    result = exec_remote("spartan", "hostname", runner=fake_runner)
-    # Assert
-    assert result.stdout == "hi"
-
-
-def test_exec_remote_basic_command_marks_zero_returncode_as_success(fake_runner):
-    # Arrange
-    fake_runner.returncode = 0
-    # Act
-    result = exec_remote("spartan", "hostname", runner=fake_runner)
+    result = exec_remote("spartan", "hostname")
     # Assert
     assert result.success is True
 
 
-def test_exec_remote_with_ssh_opts_passes_them_through_verbatim(fake_runner):
+def test_exec_remote_captures_remote_stdout(subprocess_shim):
     # Arrange
-    opts = ["-A", "-o", "StrictHostKeyChecking=no"]
+    subprocess_shim.install("ssh", rc=0, stdout="hi")
     # Act
-    exec_remote("h", "cmd", ssh_opts=opts, runner=fake_runner)
+    result = exec_remote("spartan", "hostname")
     # Assert
-    assert fake_runner.last_cmd == ["ssh", *opts, "h", "cmd"]
+    assert result.stdout == "hi"
 
 
-def test_exec_remote_check_raises_runtimeerror_on_nonzero_returncode(fake_runner):
+def test_exec_remote_passes_ssh_opts_through_verbatim(subprocess_shim):
     # Arrange
-    fake_runner.returncode = 1
-    fake_runner.stderr = "boom"
+    subprocess_shim.install("ssh", rc=0)
+    # Act
+    exec_remote("h", "cmd", ssh_opts=["-A", "-o", "StrictHostKeyChecking=no"])
+    # Assert
+    assert subprocess_shim.argv("ssh") == [
+        "-A",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "h",
+        "cmd",
+    ]
+
+
+def test_exec_remote_raises_runtimeerror_when_check_and_nonzero_exit(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", rc=1, stderr="boom")
     # Act
     ctx = pytest.raises(RuntimeError)
     # Assert
     with ctx:
-        exec_remote("h", "cmd", check=True, runner=fake_runner)
+        exec_remote("h", "cmd", check=True)
 
 
-# ---------------------------------------------------------------------
-# copy_to
-# ---------------------------------------------------------------------
-
-
-def test_copy_to_recursive_with_opts_builds_expected_scp_argv(fake_runner):
+def test_copy_to_recursive_drops_basic_flags_and_keeps_o_and_i_opts(subprocess_shim):
     # Arrange
-    opts = ["-A", "-o", "K=V", "-i", "/key"]
+    subprocess_shim.install("scp", rc=0)
     # Act
     copy_to(
         "h",
         "/local/dir",
         "~/dest",
         recursive=True,
-        ssh_opts=opts,
-        runner=fake_runner,
+        ssh_opts=["-A", "-o", "K=V", "-i", "/key"],
     )
-    # Assert
-    # `-A` is irrelevant to scp and dropped; `-o K=V` and `-i /key` survive.
-    assert fake_runner.last_cmd == [
-        "scp",
+    # Assert — -A dropped (not relevant for scp); -o K=V and -i /key kept
+    assert subprocess_shim.argv("scp") == [
         "-r",
         "-o",
         "K=V",
@@ -105,17 +98,13 @@ def test_copy_to_recursive_with_opts_builds_expected_scp_argv(fake_runner):
     ]
 
 
-# ---------------------------------------------------------------------
-# copy_from
-# ---------------------------------------------------------------------
-
-
-def test_copy_from_constructs_host_prefixed_remote_source(fake_runner):
+def test_copy_from_constructs_remote_source_argv(subprocess_shim):
     # Arrange
+    subprocess_shim.install("scp", rc=0)
     # Act
-    copy_from("h", "~/src", "/local/dest", runner=fake_runner)
+    copy_from("h", "~/src", "/local/dest")
     # Assert
-    assert fake_runner.last_cmd == ["scp", "h:~/src", "/local/dest"]
+    assert subprocess_shim.argv("scp") == ["h:~/src", "/local/dest"]
 
 
 # EOF


### PR DESCRIPTION
Replace the broken ecosystem-clone quality template (FileNotFoundError on a non-existent `_ecosystem/_core.py` + missing `scripts/quality/audit_ecosystem.py`) with the canonical single-package `scitex-dev ecosystem audit-all scitex-ssh`. Mirrors the audit `tests/develop/test_audit.py` runs.