### PR TITLE
ci(docs): make _sphinx_html commit-back step non-fatal

### DIFF
--- a/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
+++ b/.github/workflows/rtd-sphinx-build-on-ubuntu-latest.yml
@@ -47,6 +47,7 @@ jobs:
           touch src/scitex_ssh/_sphinx_html/.nojekyll
 
       - name: Commit refreshed HTML if it changed (develop push only)
+        continue-on-error: true
         if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
         run: |
           if [ -n "$(git status --porcelain src/scitex_ssh/_sphinx_html)" ]; then


### PR DESCRIPTION
Replicate scitex-python PR #284: mark only the _sphinx_html commit-back step continue-on-error so the docs workflow stops going red with GH006 on protected develop.