### PR TITLE
release v1.0.1 (wheel fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,6 @@ Documentation = "https://scitex-ssh.readthedocs.io"
 [tool.hatch.build.targets.wheel]
 packages = ["src/scitex_ssh"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"src/scitex_ssh/_sphinx_html" = "scitex_ssh/_sphinx_html"
-
-
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]


### PR DESCRIPTION
Release v1.0.1 — includes wheel-duplicate-ZIP fix so PyPI publish succeeds.