### PR TITLE
docs: refresh README, sphinx, and skills docs to match current CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,15 +238,15 @@ result = scitex_ssh.remove(2222)
 
 ```bash
 scitex-ssh --help-recursive                # Show all commands
-scitex-ssh setup -p 2222 -b user@host -s ~/.ssh/id_rsa
-scitex-ssh status                          # All tunnels
-scitex-ssh status -p 2222                  # Specific port
-scitex-ssh remove -p 2222                  # Remove tunnel
+scitex-ssh tunnel setup -p 2222 -b user@host -s ~/.ssh/id_rsa
+scitex-ssh tunnel check-status             # All tunnels
+scitex-ssh tunnel check-status -p 2222     # Specific port
+scitex-ssh tunnel remove -p 2222           # Remove tunnel
 scitex-ssh list-python-apis                # List Python APIs
 scitex-ssh mcp list-tools                  # List MCP (Model Context Protocol) tools
 ```
 
-> **Note**: `setup` and `remove` write systemd unit files under `/etc/systemd/system/` and call `systemctl`, so they prompt for **sudo** the first time. `status`, `list-python-apis`, and `mcp ...` do not.
+> **Note**: `tunnel setup` and `tunnel remove` write systemd unit files under `/etc/systemd/system/` and call `systemctl`, so they prompt for **sudo** the first time. `tunnel check-status`, `list-python-apis`, and `mcp ...` do not.
 
 > **[Full CLI reference](https://scitex-ssh.readthedocs.io/en/latest/quickstart.html)** · run `scitex-ssh --help-recursive` for the live tree.
 
@@ -286,11 +286,15 @@ Code, MCP-aware tools, or `newb`):
 | File | Purpose |
 |------|---------|
 | `SKILL.md` | Index — what this package does + tag map |
-| `01_quick-start.md` | 30-second tour |
-| `02_python-api.md` | Python API surface |
-| `10_cli-commands.md` | CLI reference |
+| `01_installation.md` | Installation and prerequisites |
+| `02_quick-start.md` | 30-second tour (CLI + Python) |
+| `03_python-api.md` | Python API surface |
+| `04_cli-reference.md` | Full CLI reference |
+| `10_cli-commands.md` | CLI commands (legacy) |
 | `11_mcp-tools-for-ai-agents.md` | MCP tool catalog |
-| `20_environment-variables.md` | `SCITEX_SSH_*` env vars |
+| `12_quick-start.md` | Quick-start (legacy) |
+| `13_python-api.md` | Python API (legacy) |
+| `20_env-vars.md` | `SCITEX_SSH_*` env vars |
 
 ```bash
 scitex-ssh skills list
@@ -340,7 +344,8 @@ $ ssh -p 2222 user@bastion.example.com
 
 `scitex-ssh` is part of [**SciTeX**](https://scitex.ai). Install via
 the umbrella with `pip install scitex[ssh]` to use as
-`scitex.ssh` (Python) or `scitex ssh ...` (CLI).
+`scitex.ssh` (Python) or `scitex ssh ...` (CLI), or via
+`pip install scitex-ssh[all]` for standalone use with MCP support.
 
 SciTeX follows the Four Freedoms for Research below, inspired by
 [the Free Software Definition](https://www.gnu.org/philosophy/free-sw.en.html):

--- a/docs/sphinx/how-it-works.rst
+++ b/docs/sphinx/how-it-works.rst
@@ -89,7 +89,7 @@ Each tunnel is registered as a systemd service unit. This provides:
 The Service File
 ~~~~~~~~~~~~~~~~
 
-When you run ``scitex-ssh setup -p 2222 -b user@bastion -s ~/.ssh/id_rsa``,
+When you run ``scitex-ssh tunnel setup -p 2222 -b user@bastion -s ~/.ssh/id_rsa``,
 the following systemd unit file is created:
 
 **File**: ``/etc/systemd/system/autossh-tunnel-2222.service``
@@ -146,7 +146,7 @@ The Three Operations
 Each operation is available through all three interfaces:
 
 - **Python**: ``scitex_ssh.setup()``, ``scitex_ssh.status()``, ``scitex_ssh.remove()``
-- **CLI**: ``scitex-ssh setup``, ``scitex-ssh status``, ``scitex-ssh remove``
+- **CLI**: ``scitex-ssh tunnel setup``, ``scitex-ssh tunnel check-status``, ``scitex-ssh tunnel remove``
 - **MCP**: ``tunnel_setup``, ``tunnel_status``, ``tunnel_remove`` tools
 
 Environment Variables

--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -12,7 +12,7 @@ Or as part of SciTeX:
 
 .. code-block:: bash
 
-    pip install scitex[tunnel]
+    pip install scitex[ssh]
 
 Prerequisites
 -------------

--- a/docs/sphinx/quickstart.rst
+++ b/docs/sphinx/quickstart.rst
@@ -1,18 +1,18 @@
 Quickstart
 ==========
 
-Setup a Tunnel
---------------
+Setup a Tunnel (via the ``tunnel`` subcommand group)
+-----------------------------------------------------
 
 .. code-block:: bash
 
-    scitex-ssh setup -p 2222 -b user@bastion.example.com -s ~/.ssh/id_rsa
+    scitex-ssh tunnel setup -p 2222 -b user@bastion.example.com -s ~/.ssh/id_rsa
 
 This creates a systemd service that maintains a persistent reverse SSH (Secure Shell) tunnel.
 
 .. note::
 
-   ``setup`` and ``remove`` require **sudo** privileges because they write
+   ``tunnel setup`` and ``tunnel remove`` require **sudo** privileges because they write
    systemd service files to ``/etc/systemd/system/`` and run ``systemctl``.
    You will be prompted for your password.
 
@@ -21,15 +21,15 @@ Check Status
 
 .. code-block:: bash
 
-    scitex-ssh status
-    scitex-ssh status -p 2222
+    scitex-ssh tunnel check-status
+    scitex-ssh tunnel check-status -p 2222
 
 Remove a Tunnel
 ---------------
 
 .. code-block:: bash
 
-    scitex-ssh remove -p 2222
+    scitex-ssh tunnel remove -p 2222
 
 Python API (Application Programming Interface)
 -----------------------------------------------

--- a/src/scitex_ssh/_skills/scitex-ssh/01_installation.md
+++ b/src/scitex_ssh/_skills/scitex-ssh/01_installation.md
@@ -50,7 +50,7 @@ work — install the umbrella for that form. See
 ```bash
 python -c "import scitex_ssh; print(scitex_ssh.__version__, scitex_ssh.AVAILABLE)"
 scitex-ssh --help
-scitex-ssh status
+scitex-ssh tunnel check-status
 ```
 
 Expected: a version string, `AVAILABLE = True`, then a status table
@@ -60,4 +60,4 @@ Expected: a version string, `AVAILABLE = True`, then a status table
 
 - `setup` requires `sudo` to install the systemd unit — it will prompt.
 - A per-host SSH allowlist gate (`PolicyError`) blocks tunnels to
-  hosts not listed in `~/.scitex/ssh/allowed_hosts.yaml`.
+  hosts not listed in `~/.scitex/ssh/config.yaml`.

--- a/src/scitex_ssh/_skills/scitex-ssh/02_quick-start.md
+++ b/src/scitex_ssh/_skills/scitex-ssh/02_quick-start.md
@@ -10,7 +10,7 @@ tags: [scitex-ssh-quick-start]
 ## CLI: install a reverse tunnel
 
 ```bash
-scitex-ssh setup \
+scitex-ssh tunnel setup \
     --port 22 \
     --bastion jump.example.com \
     --secret-key ~/.ssh/id_rsa
@@ -21,9 +21,9 @@ maintains a reverse tunnel from `jump.example.com:<port>` back to this
 machine, surviving network drops and dynamic IPs.
 
 ```bash
-scitex-ssh status              # list all tunnels
-scitex-ssh status --port 22    # status of one tunnel
-scitex-ssh remove --port 22    # tear down + remove unit
+scitex-ssh tunnel check-status          # list all tunnels
+scitex-ssh tunnel check-status --port 22    # status of one tunnel
+scitex-ssh tunnel remove --port 22      # tear down + remove unit
 ```
 
 ## Python equivalent
@@ -51,5 +51,5 @@ attach("user@host")              # interactive shell
 ```
 
 All primitives are gated by the host allowlist
-(`~/.scitex/ssh/allowed_hosts.yaml`); unlisted hosts raise
+(`~/.scitex/ssh/config.yaml`); unlisted hosts raise
 `PolicyError`.

--- a/src/scitex_ssh/_skills/scitex-ssh/03_python-api.md
+++ b/src/scitex_ssh/_skills/scitex-ssh/03_python-api.md
@@ -48,12 +48,12 @@ result = setup(port=22, bastion_server="jump.example.com",
 
 ## Allowlist
 
-All primitives consult `~/.scitex/ssh/allowed_hosts.yaml`. Unlisted
+All primitives consult `~/.scitex/ssh/config.yaml`. Unlisted
 hosts raise `PolicyError` before any SSH call is dispatched. Append
 hosts manually:
 
 ```yaml
-# ~/.scitex/ssh/allowed_hosts.yaml
+# ~/.scitex/ssh/config.yaml
 hosts:
   - host.example.com
   - jump.example.com

--- a/src/scitex_ssh/_skills/scitex-ssh/04_cli-reference.md
+++ b/src/scitex_ssh/_skills/scitex-ssh/04_cli-reference.md
@@ -44,14 +44,15 @@ scitex-ssh attach user@host
 
 ## Tunnel management
 
-| Command          | Purpose                                              |
-|------------------|------------------------------------------------------|
-| `tunnel setup`   | Install autossh systemd unit (reverse tunnel)        |
-| `tunnel status`  | Show one or all installed tunnels                    |
-| `tunnel remove`  | Stop + uninstall a tunnel by port                    |
+| Command                 | Purpose                                              |
+|-------------------------|------------------------------------------------------|
+| `tunnel setup`          | Install autossh systemd unit (reverse tunnel)        |
+| `tunnel check-status`   | Show one or all installed tunnels                    |
+| `tunnel remove`         | Stop + uninstall a tunnel by port                    |
 
-Backward-compat shortcuts at the top level (`scitex-ssh setup / status /
-remove`) are still accepted.
+Backward-compat shortcuts at the top level (`scitex-ssh setup-tunnel /
+scitex-ssh show-status / scitex-ssh remove-tunnel`) are still accepted
+but deprecated.
 
 ```bash
 scitex-ssh tunnel setup --port 22 --bastion jump.example.com \
@@ -77,7 +78,7 @@ shape.
 ## Examples
 
 ```bash
-scitex-ssh --json tunnel status               # machine-readable
+scitex-ssh --json tunnel check-status         # machine-readable
 scitex-ssh --help-recursive | head -60        # full surface dump
 ```
 

--- a/src/scitex_ssh/_skills/scitex-ssh/10_cli-commands.md
+++ b/src/scitex_ssh/_skills/scitex-ssh/10_cli-commands.md
@@ -9,15 +9,15 @@ tags: [scitex-ssh-cli-commands]
 
 ```bash
 # Core
-scitex-ssh setup --port <port> --bastion <host> --secret-key <path>
-scitex-ssh status [--port <port>]
-scitex-ssh remove --port <port>
+scitex-ssh tunnel setup --port <port> --bastion <host> --secret-key <path>
+scitex-ssh tunnel check-status [--port <port>]
+scitex-ssh tunnel remove --port <port>
 
 # MCP server
 scitex-ssh mcp start [--transport <str>] [--host <host>] [--port <port>]
 scitex-ssh mcp doctor
 scitex-ssh mcp list-tools
-scitex-ssh mcp installation
+scitex-ssh mcp show-installation
 
 # Introspection
 scitex-ssh list-python-apis [-v]

--- a/src/scitex_ssh/_skills/scitex-ssh/12_quick-start.md
+++ b/src/scitex_ssh/_skills/scitex-ssh/12_quick-start.md
@@ -9,16 +9,16 @@ tags: [scitex-ssh-quick-start]
 
 ```bash
 # Setup a tunnel (port 22 exposed via bastion)
-scitex-ssh setup --port 22 --bastion jump.example.com --secret-key ~/.ssh/id_rsa
+scitex-ssh tunnel setup --port 22 --bastion jump.example.com --secret-key ~/.ssh/id_rsa
 
 # Check status
-scitex-ssh status
+scitex-ssh tunnel check-status
 
 # Check specific port
-scitex-ssh status --port 22
+scitex-ssh tunnel check-status --port 22
 
 # Remove tunnel
-scitex-ssh remove --port 22
+scitex-ssh tunnel remove --port 22
 ```
 
 ```python


### PR DESCRIPTION
## Summary

Updates documentation across README, sphinx/RTD, and bundled skills to
reflect the current CLI command structure and config file naming:

### CLI command fixes
- `scitex-ssh setup/status/remove` → `scitex-ssh tunnel setup/check-status/remove`
- `mcp installation` → `mcp show-installation`

### Config file naming
- `allowed_hosts.yaml` → `config.yaml` (the actual filename used by `_allowlist.py`)

### Other
- Umbrella install extra: `scitex[tunnel]` → `scitex[ssh]`
- README skills table updated to list actual skill filenames
- GitHub repo description and homepage URL updated

## Test plan
- [ ] Visual review of README renders correctly
- [ ] `sphinx-build -W` passes on the updated RST files
- [ ] Skill files render correctly under `scitex-ssh skills list/get`