### PR TITLE
fix(docs/example): unwrap outer PATH: from example config/PATH.yaml (PS-PATH-001)

### DIFF
--- a/docs/to_claude/examples/example-python-project-scitex/config/PATH.yaml
+++ b/docs/to_claude/examples/example-python-project-scitex/config/PATH.yaml
@@ -1,30 +1,38 @@
 # Timestamp: "2025-02-15 02:01:15 (ywatanabe)"
 # File: /home/ywatanabe/proj/example-scitex-project/config/PATH.yaml
+#
+# PS-PATH-001: per the rule, config/PATH.yaml exposes its top-level
+# keys directly under CONFIG.PATH.<KEY>. The filename already names
+# the namespace — wrapping the contents in an outer `PATH:` key would
+# put the real entries at CONFIG.PATH.PATH.<KEY> and every
+# `eval(CONFIG.PATH.<KEY>)` access site would crash with
+# AttributeError. So no outer wrapper; children sit at the top level.
+# See scitex-dev _skills/scientific/02_research-project/
+# 03_project-structure-config-and-data.md §`PATH.yaml`.
 
-PATH:
-  MNIST:
-    RAW:
-      "./data/mnist/raw/"
-    LOADER:
-      TRAIN:
-        "./data/mnist/train_loader.pkl"
-      TEST:
-        "./data/mnist/test_loader.pkl"
-    FLATTENED:
-      TRAIN:
-        "./data/mnist/train_flattened.npy"
-      TEST:
-        "./data/mnist/test_flattened.npy"
-    LABELS:      
-      TRAIN:
-        "./data/mnist/train_labels.npy"
-      TEST:
-        "./data/mnist/test_labels.npy"
-    FIGURES:
-      "./data/mnist/figures/"
-    MODELS:
-      "./data/mnist/models/"
-    MODEL_SVM:
-      f"{CONFIG.PATH.MNIST.MODELS}/mnist_svm.pkl"
+MNIST:
+  RAW:
+    "./data/mnist/raw/"
+  LOADER:
+    TRAIN:
+      "./data/mnist/train_loader.pkl"
+    TEST:
+      "./data/mnist/test_loader.pkl"
+  FLATTENED:
+    TRAIN:
+      "./data/mnist/train_flattened.npy"
+    TEST:
+      "./data/mnist/test_flattened.npy"
+  LABELS:
+    TRAIN:
+      "./data/mnist/train_labels.npy"
+    TEST:
+      "./data/mnist/test_labels.npy"
+  FIGURES:
+    "./data/mnist/figures/"
+  MODELS:
+    "./data/mnist/models/"
+  MODEL_SVM:
+    f"{CONFIG.PATH.MNIST.MODELS}/mnist_svm.pkl"
 
 # EOF


### PR DESCRIPTION
## Summary

PS-PATH-001 fires on every audit run (`tests` + `quality` workflows go red) because the canonical example config/PATH.yaml at `docs/to_claude/examples/example-python-project-scitex/config/PATH.yaml` ships with an outer `PATH:` wrapper.

The filename already supplies the `CONFIG.PATH` namespace, so wrapping the contents puts every key one level too deep (`CONFIG.PATH.PATH.<KEY>`) — every `eval(CONFIG.PATH.<KEY>)` access site would `AttributeError` at runtime, which is the exact bug the rule guards.

## Fix

- Drop the outer `PATH:` line and dedent its children one level so they sit at the top of the file.
- Add a header comment naming the rule + linking the skill so a future editor doesn't re-introduce the wrapper.

Mechanical — no semantic change.

The file is tracked but lives under a gitignored prefix (`docs/to_claude/`) so it required `git add -f` to stage; consistent with the existing convention for the example tree.

## Test plan

- [ ] CI tests + quality matrix GREEN (PS-PATH-001 step now passes)
- [ ] import-smoke continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
