### PR TITLE
chore(gitattributes): exclude Sphinx HTML from linguist stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 # Sphinx-generated docs bundle — exclude from GitHub language stats.
 src/*/_sphinx_html/** linguist-generated
+
+# 2026-06-13: exclude Sphinx-generated HTML from GitHub Linguist language stats
+# Refs: ywatanabe1989/scitex-dev#168 (operator-direct)
+docs/_build/** linguist-generated
+docs/build/** linguist-generated
+**/_sphinx_html/** linguist-documentation


### PR DESCRIPTION
Operator-flagged: GitHub primary language was misclassified as HTML because committed Sphinx output dominates linguist's count. .gitattributes now marks docs/_build + **/_sphinx_html as generated/documentation so linguist recomputes the primary language to Python.

Cross-repo ref: ywatanabe1989/scitex-dev#168 (operator-direct GO via lead 2026-06-13).