### PR TITLE
ci(ssh): shift nightly cron to off-peak JST

### DIFF
--- a/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
+++ b/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
@@ -13,7 +13,7 @@ on:
   pull_request:
     branches: [main, develop]
   schedule:
-    - cron: "0 7 * * *"  # nightly 07:00 UTC
+    - cron: "0 17 * * *"  # nightly 17:00 UTC (~02:00 JST), off-peak
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/newb-docs-quality-on-ubuntu-latest.yml
+++ b/.github/workflows/newb-docs-quality-on-ubuntu-latest.yml
@@ -9,7 +9,7 @@ name: newb
 # are intentionally NOT enabled here (LLM API cost + run time).
 on:
   schedule:
-    - cron: "0 4 * * 1"        # weekly Monday 04:00 UTC
+    - cron: "0 17 * * 1"  # weekly Mon 17:00 UTC (~Tue 02:00 JST)
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main, develop]
   schedule:
-    - cron: "0 7 * * *"  # nightly 07:00 UTC
+    - cron: "0 17 * * *"  # nightly 17:00 UTC (~02:00 JST), off-peak
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/scitex-ssh-quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/scitex-ssh-quality-audit-on-ubuntu-latest.yml
@@ -15,7 +15,7 @@ name: quality
 
 on:
   schedule:
-    - cron: "0 8 * * *"  # 08:00 UTC, after the 07:00 per-repo Test runs
+    - cron: "0 18 * * *"  # 18:00 UTC (~03:00 JST), after Test
   workflow_dispatch:
   push:
     branches: [develop]


### PR DESCRIPTION
Nightly crons -> 0 17/0 18 UTC (~2-3 AM JST). Pure schedule change. Gated on green before merge.