### PR TITLE
fix(audit): whitelist `attach` as intransitive verb — green the develop pytest matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ GITIGNORED/
 !.scitex/dev/
 .scitex/dev/*
 !.scitex/dev/config.yaml
+# audit-cli §1 vocabulary overrides — MUST be tracked so CI's audit gate
+# (tests/develop/test_audit.py) reads the same intransitive-verb whitelist.
+!.scitex/dev/cli-audit-dict.yaml
 
 # Emacs
 *~

--- a/.scitex/dev/cli-audit-dict.yaml
+++ b/.scitex/dev/cli-audit-dict.yaml
@@ -1,0 +1,23 @@
+# Project-local CLI audit dictionary for scitex-ssh.
+#
+# Extends the bundled scitex-dev catalog with package-specific tokens.
+# See: scitex-dev/_skills/general/03_interface_02_cli/07_audit-cli.md
+#
+# Format expected by
+# scitex_dev/_cli/audit/_summary/_audit.py::_load_custom_dict():
+#   nouns:              [...]
+#   transitive_verbs:   [...]
+#   intransitive_verbs: [...]
+
+intransitive_verbs:
+  # audit-cli §1 escape hatch (the same mechanism `next` uses, and that
+  # scitex-todo uses for watch/close/comment): Moby's POS corpus
+  # classifies `attach` as BOTH a noun and a verb, so the leaf-noun
+  # rule — tightened by scitex-dev fe5a254 (operator directive 13316) to
+  # catch multi-class homonyms — flags it. In this CLI's grammar it is
+  # unambiguously the imperative the user types to act on a session:
+  #   scitex-ssh attach <session>   — attach to a multiplexed SSH session
+  # (mirrors the established `tmux attach` / `screen -r` pattern; a
+  # rename to `<verb>-attach` / `attach start` would be worse UX).
+  # Declaring it an intransitive verb records that intent and clears §1.
+  - attach


### PR DESCRIPTION
## Problem

`develop` pytest-matrix (py3.11/3.12/3.13) has been **red** since the
nightly-cron shift commit. The failing test is the audit-conformance gate:

```
FAILED tests/develop/test_audit.py::test_audit_all_clean
  AssertionError: audit-all reported violations for 'scitex-ssh' (exit=1).
  ERRO: scitex-ssh: 1 error(s)
  ERRO:   [§1] scitex-ssh attach: leaf token looks like a noun ...
```

180 of 181 tests pass; only this one gate fails.

## Root cause (auditor drift, not a code regression)

`scitex-dev` audit-cli §1 was **intentionally tightened** in
`scitex-dev fe5a254` ("catch noun-as-verb starts and multi-class top-level
leaves", operator directive 13316, 2026-06-14) and that change reached the
PyPI corpus CI installs. It now flags leaf tokens that Moby's POS corpus
classifies as **both** noun and verb. `scitex-ssh attach` tripped it.

`attach` is unambiguously the imperative verb here — attach to a multiplexed
SSH session, exactly the established `tmux attach` / `screen -r` pattern.

## Fix

Use the auditor's **own sanctioned escape hatch** (`intransitive_verbs:` in
`.scitex/dev/cli-audit-dict.yaml`) — the same mechanism `next` (scitex-todo)
and figrecipe's `plot`/`crop`/`extract`/`info` already use. No rename
(worse UX), no mock, no skip/xfail.

- `.scitex/dev/cli-audit-dict.yaml`: declare `attach` an intransitive verb
- `.gitignore`: un-ignore `cli-audit-dict.yaml` (it was caught by
  `.scitex/dev/*`), mirroring figrecipe / scitex-todo so CI reads the same
  whitelist

## Verification

- `scitex-dev ecosystem audit-all scitex-ssh` → exit 0 (was exit 1)
- Full suite locally (uv venv, py3.12, `.[all,dev]`): **181 passed**