### PR TITLE
feat(ssh): add sync_dir rsync primitive + `scitex-ssh sync` CLI

### DIFF
--- a/src/scitex_ssh/__init__.py
+++ b/src/scitex_ssh/__init__.py
@@ -10,7 +10,14 @@ import subprocess
 from ._allowlist import PolicyError
 from ._allowlist import is_allowed as _is_allowed
 from ._allowlist import require as _require_allowed
-from ._primitives import SSHResult, attach, copy_from, copy_to, exec_remote
+from ._primitives import (
+    SSHResult,
+    attach,
+    copy_from,
+    copy_to,
+    exec_remote,
+    sync_dir,
+)
 
 __all__ = [
     "__version__",
@@ -20,6 +27,7 @@ __all__ = [
     "copy_from",
     "copy_to",
     "exec_remote",
+    "sync_dir",
     "setup",
     "remove",
     "status",

--- a/src/scitex_ssh/_cli/_main.py
+++ b/src/scitex_ssh/_cli/_main.py
@@ -7,12 +7,12 @@ import click
 
 from ._introspect import list_python_apis
 from ._mcp import mcp
-from ._primitives import attach_cmd, copy_cmd, exec_cmd
+from ._primitives import attach_cmd, copy_cmd, exec_cmd, sync_cmd
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 COMMAND_CATEGORIES = [
-    ("SSH Primitives", ["exec", "copy", "attach"]),
+    ("SSH Primitives", ["exec", "copy", "sync", "attach"]),
     ("Tunnel Management", ["tunnel"]),
     ("Integration", ["mcp", "list-python-apis"]),
 ]
@@ -360,6 +360,7 @@ def show_status_deprecated(port):
 
 main.add_command(exec_cmd)
 main.add_command(copy_cmd)
+main.add_command(sync_cmd)
 main.add_command(attach_cmd)
 main.add_command(list_python_apis)
 main.add_command(mcp)

--- a/src/scitex_ssh/_cli/_primitives.py
+++ b/src/scitex_ssh/_cli/_primitives.py
@@ -117,6 +117,84 @@ def copy_cmd(src, dest, recursive, ssh_opts, dry_run, yes):
     raise SystemExit(result.returncode)
 
 
+@click.command("sync")
+@click.argument("src")
+@click.argument("dest")
+@click.option(
+    "--exclude",
+    "exclude",
+    multiple=True,
+    help="Glob to exclude (repeatable), e.g. --exclude index.db --exclude '*.db-wal'.",
+)
+@click.option("--delete", is_flag=True, help="Mirror deletions (rsync --delete).")
+@click.option(
+    "--extra-opts",
+    default=None,
+    help='Extra rsync flags as one shell-quoted string (e.g. "--checksum --mkpath").',
+)
+@click.option(
+    "--ssh-opts",
+    default=None,
+    help="Extra ssh flags as a single shell-quoted string (wired via rsync -e).",
+)
+@click.option("--dry-run", is_flag=True, help="Print plan without running rsync.")
+@click.option(
+    "-y", "--yes", is_flag=True, help="Suppress interactive confirmation (assume yes)."
+)
+def sync_cmd(src, dest, exclude, delete, extra_opts, ssh_opts, dry_run, yes):
+    """Rsync a directory one-way between local and a remote HOST:PATH.
+
+    \b
+    Example:
+      $ scitex-ssh sync ~/.scitex/scholar/library/ spartan:~/.scitex/scholar/library/ \\
+          --exclude index.db --exclude '*.db-wal' --exclude '*.db-shm'
+      $ scitex-ssh sync spartan:~/data/ ./data/ --delete
+    """
+    src_host, src_path = _split_host_path(src)
+    dest_host, dest_path = _split_host_path(dest)
+
+    if src_host and dest_host:
+        click.secho(
+            "ERROR: remote-to-remote sync is not supported.", fg="red", err=True
+        )
+        raise SystemExit(2)
+    if not src_host and not dest_host:
+        click.secho(
+            "ERROR: exactly one of SRC or DEST must be HOST:PATH.", fg="red", err=True
+        )
+        raise SystemExit(2)
+
+    if dest_host:
+        direction, host, local, remote = "push", dest_host, src_path, dest_path
+    else:
+        direction, host, local, remote = "pull", src_host, dest_path, src_path
+
+    if dry_run:
+        click.echo(
+            f"DRY RUN — would rsync ({direction}) {src} -> {dest} "
+            f"(exclude={list(exclude)}, delete={delete})"
+        )
+        return
+
+    from scitex_ssh import sync_dir
+
+    result = sync_dir(
+        host,
+        local,
+        remote,
+        direction=direction,
+        exclude=exclude,
+        delete=delete,
+        extra_opts=_split_opts(extra_opts),
+        ssh_opts=_split_opts(ssh_opts),
+    )
+    if result.stdout:
+        click.echo(result.stdout, nl=False)
+    if result.stderr:
+        click.echo(result.stderr, err=True, nl=False)
+    raise SystemExit(result.returncode)
+
+
 @click.command("attach")
 @click.argument("host")
 @click.option("--command", "-c", default=None, help="Command to run after attaching.")

--- a/src/scitex_ssh/_primitives.py
+++ b/src/scitex_ssh/_primitives.py
@@ -97,6 +97,89 @@ def copy_from(
     return SSHResult(proc.returncode, proc.stdout, proc.stderr)
 
 
+def sync_dir(
+    host: str,
+    local: str,
+    remote: str,
+    *,
+    direction: str = "push",
+    exclude: Sequence[str] = (),
+    delete: bool = False,
+    extra_opts: Sequence[str] = (),
+    ssh_opts: Sequence[str] = (),
+    runner=None,
+) -> SSHResult:
+    """rsync a directory one-way between local and ``host`` over ssh.
+
+    A thin, policy-free wrapper over ``rsync -a`` for syncing a directory
+    tree between the local machine and a remote host. Unlike ``copy_to`` /
+    ``copy_from`` (single-shot scp, no delta/exclude), this does an
+    incremental transfer with per-file excludes — the right tool for
+    mirroring a per-user dir (e.g. ``~/.scitex/scholar/library``) between
+    a WSL host and an HPC login node.
+
+    The primitive is deliberately generic: it never decides *what* to
+    exclude or *whether* to delete. Callers pass ``exclude`` globs and any
+    ``extra_opts`` (``--checksum``, ``--mkpath``, ``--dry-run``, …); any
+    post-sync step (e.g. rebuilding a derived index) is the caller's job
+    via ``exec_remote``.
+
+    Parameters
+    ----------
+    host : str
+        Remote ssh host (an ``~/.ssh/config`` alias like ``spartan`` works).
+    local : str
+        Local directory path. Trailing-slash semantics are rsync's and are
+        passed through verbatim: ``src/`` copies *contents*, ``src`` copies
+        the dir itself. The caller controls this.
+    remote : str
+        Remote directory path on ``host``.
+    direction : {"push", "pull"}
+        ``push`` sends ``local`` → ``host:remote`` (default); ``pull`` pulls
+        ``host:remote`` → ``local``.
+    exclude : sequence of str
+        Glob patterns passed as ``--exclude=<pat>`` (e.g. ``index.db``,
+        ``*.db-wal``). Never ship a live sqlite/WAL file — exclude it and
+        rebuild or snapshot it caller-side.
+    delete : bool
+        Add ``--delete`` (mirror deletions). Off by default: an additive
+        merge library should not have receiver-side files deleted.
+    extra_opts : sequence of str
+        Raw rsync flags appended verbatim (escape hatch for
+        ``--checksum``, ``--mkpath``, ``--dry-run``, ``--info=progress2``).
+    ssh_opts : sequence of str
+        ssh flags for the transport; wired via ``-e 'ssh <opts>'`` (e.g.
+        ``['-o', 'BatchMode=yes']`` for non-interactive cron).
+    runner : callable, optional
+        ``subprocess.run``-shaped invoker; defaults to ``subprocess.run``.
+        Pass a hand-rolled fake from tests to observe argv without mocks.
+    """
+    if direction not in ("push", "pull"):
+        raise ValueError(f"direction must be 'push' or 'pull', got {direction!r}")
+    if runner is None:
+        runner = subprocess.run
+
+    local_end = local
+    remote_end = f"{host}:{remote}"
+    src, dest = (
+        (local_end, remote_end) if direction == "push" else (remote_end, local_end)
+    )
+
+    cmd = [
+        "rsync",
+        "-a",
+        "--partial",
+        *(["--delete"] if delete else []),
+        *extra_opts,
+        *[f"--exclude={pat}" for pat in exclude],
+        *(["-e", "ssh " + " ".join(ssh_opts)] if ssh_opts else []),
+        src,
+        dest,
+    ]
+    proc = runner(cmd, capture_output=True, text=True)
+    return SSHResult(proc.returncode, proc.stdout, proc.stderr)
+
+
 def attach(
     host: str,
     command: str | None = None,

--- a/tests/scitex_ssh/_cli/test__primitives.py
+++ b/tests/scitex_ssh/_cli/test__primitives.py
@@ -21,6 +21,7 @@ from scitex_ssh._cli._primitives import (
     attach_cmd,
     copy_cmd,
     exec_cmd,
+    sync_cmd,
 )
 
 
@@ -234,6 +235,85 @@ class TestCopyCmd:
         runner.invoke(copy_cmd, ["myhost:/etc/hostname", "./hostname"])
         # Assert
         assert subprocess_shim.argv("scp") == ["myhost:/etc/hostname", "./hostname"]
+
+
+class TestSyncCmd:
+    def test_dry_run_exits_zero(self):
+        # Arrange
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(
+            sync_cmd, ["./lib/", "spartan:~/lib/", "--dry-run"]
+        )
+        # Assert
+        assert result.exit_code == 0
+
+    def test_dry_run_announces_push_direction(self):
+        # Arrange
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(
+            sync_cmd, ["./lib/", "spartan:~/lib/", "--dry-run"]
+        )
+        # Assert
+        assert "push" in result.output
+
+    def test_local_to_local_sync_exits_two(self):
+        # Arrange
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(sync_cmd, ["./a/", "./b/"])
+        # Assert
+        assert result.exit_code == 2
+
+    def test_remote_to_remote_sync_reports_unsupported(self):
+        # Arrange
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(sync_cmd, ["h1:/a/", "h2:/b/"])
+        # Assert
+        assert "remote-to-remote" in result.output
+
+    def test_push_invokes_rsync_once(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("rsync", rc=0)
+        runner = CliRunner()
+        # Act
+        runner.invoke(sync_cmd, ["./lib/", "spartan:~/lib/"])
+        # Assert
+        assert subprocess_shim.call_count("rsync") == 1
+
+    def test_push_builds_remote_dest_argv(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("rsync", rc=0)
+        runner = CliRunner()
+        # Act
+        runner.invoke(sync_cmd, ["./lib/", "spartan:~/lib/"])
+        # Assert
+        argv = subprocess_shim.argv("rsync")
+        assert argv[-2:] == ["./lib/", "spartan:~/lib/"]
+
+    def test_exclude_options_reach_rsync(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("rsync", rc=0)
+        runner = CliRunner()
+        # Act
+        runner.invoke(
+            sync_cmd,
+            ["./lib/", "spartan:~/lib/", "--exclude", "index.db", "--exclude", "*.db-wal"],
+        )
+        # Assert
+        argv = subprocess_shim.argv("rsync")
+        assert "--exclude=index.db" in argv and "--exclude=*.db-wal" in argv
+
+    def test_propagates_nonzero_returncode(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("rsync", rc=23, stderr="partial\n")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(sync_cmd, ["./lib/", "spartan:~/lib/"])
+        # Assert
+        assert result.exit_code == 23
 
 
 def _run_attach(host, *, bin_dir):

--- a/tests/scitex_ssh/test__primitives.py
+++ b/tests/scitex_ssh/test__primitives.py
@@ -194,8 +194,9 @@ def test_sync_dir_returns_sshresult_instance(subprocess_shim):
 
 def test_sync_dir_rejects_unknown_direction():
     # Arrange
+    # Act
     ctx = pytest.raises(ValueError)
-    # Act / Assert
+    # Assert
     with ctx:
         sync_dir("h", "/l/", "~/r/", direction="sideways")
 

--- a/tests/scitex_ssh/test__primitives.py
+++ b/tests/scitex_ssh/test__primitives.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from scitex_ssh import SSHResult, copy_from, copy_to, exec_remote
+from scitex_ssh import SSHResult, copy_from, copy_to, exec_remote, sync_dir
 
 
 def test_exec_remote_builds_plain_ssh_argv_from_host_and_command(subprocess_shim):
@@ -105,6 +105,99 @@ def test_copy_from_constructs_remote_source_argv(subprocess_shim):
     copy_from("h", "~/src", "/local/dest")
     # Assert
     assert subprocess_shim.argv("scp") == ["h:~/src", "/local/dest"]
+
+
+def test_sync_dir_push_puts_remote_dest_last(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("rsync", rc=0)
+    # Act
+    sync_dir("spartan", "/local/lib/", "~/lib/")
+    # Assert
+    assert subprocess_shim.argv("rsync") == [
+        "-a",
+        "--partial",
+        "/local/lib/",
+        "spartan:~/lib/",
+    ]
+
+
+def test_sync_dir_pull_puts_remote_src_first(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("rsync", rc=0)
+    # Act
+    sync_dir("spartan", "/local/lib/", "~/lib/", direction="pull")
+    # Assert
+    assert subprocess_shim.argv("rsync") == [
+        "-a",
+        "--partial",
+        "spartan:~/lib/",
+        "/local/lib/",
+    ]
+
+
+def test_sync_dir_renders_each_exclude_as_a_flag(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("rsync", rc=0)
+    # Act
+    sync_dir("h", "/l/", "~/r/", exclude=["index.db", "*.db-wal"])
+    # Assert
+    argv = subprocess_shim.argv("rsync")
+    assert "--exclude=index.db" in argv and "--exclude=*.db-wal" in argv
+
+
+def test_sync_dir_omits_delete_by_default(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("rsync", rc=0)
+    # Act
+    sync_dir("h", "/l/", "~/r/")
+    # Assert
+    assert "--delete" not in subprocess_shim.argv("rsync")
+
+
+def test_sync_dir_adds_delete_when_requested(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("rsync", rc=0)
+    # Act
+    sync_dir("h", "/l/", "~/r/", delete=True)
+    # Assert
+    assert "--delete" in subprocess_shim.argv("rsync")
+
+
+def test_sync_dir_wires_ssh_opts_into_e_flag(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("rsync", rc=0)
+    # Act
+    sync_dir("h", "/l/", "~/r/", ssh_opts=["-o", "BatchMode=yes"])
+    # Assert
+    argv = subprocess_shim.argv("rsync")
+    assert argv[argv.index("-e") + 1] == "ssh -o BatchMode=yes"
+
+
+def test_sync_dir_appends_extra_opts_verbatim(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("rsync", rc=0)
+    # Act
+    sync_dir("h", "/l/", "~/r/", extra_opts=["--checksum", "--mkpath"])
+    # Assert
+    argv = subprocess_shim.argv("rsync")
+    assert "--checksum" in argv and "--mkpath" in argv
+
+
+def test_sync_dir_returns_sshresult_instance(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("rsync", rc=0, stdout="sent")
+    # Act
+    result = sync_dir("h", "/l/", "~/r/")
+    # Assert
+    assert isinstance(result, SSHResult)
+
+
+def test_sync_dir_rejects_unknown_direction():
+    # Arrange
+    ctx = pytest.raises(ValueError)
+    # Act / Assert
+    with ctx:
+        sync_dir("h", "/l/", "~/r/", direction="sideways")
 
 
 # EOF


### PR DESCRIPTION
## Summary
- Adds `sync_dir(host, local, remote, *, direction, exclude, delete, extra_opts, ssh_opts, runner)` to `scitex_ssh._primitives` — a thin, policy-free one-way `rsync -a --partial` wrapper over ssh (sibling to `copy_to`/`copy_from`, which are single-shot scp with no delta/exclude).
- Exposes it as `scitex-ssh sync SRC DEST` under **SSH Primitives** (push/pull inferred from which side is `HOST:PATH`, `--exclude` repeatable, `--delete`, `--extra-opts`, `--ssh-opts`, `--dry-run`).
- Exported from the package root.

## Why
Requested by scitex-dev for the `scholar-library-cross-machine-sync` JobSpec: neurovista's manuscript has stub citations because `~/.scitex/scholar/library` is enriched on the WSL host but never reaches Spartan (where it compiles). `scp` can't do incremental/excluded sync; this gives a stable API the cron JobSpec can call instead of a raw rsync string.

Design is deliberately **policy-free**: the primitive never decides *what* to exclude or *whether* to delete, and does no post-sync step. The caller (JobSpec) drives:
- exclude the live sqlite (`--exclude index.db --exclude '*.db-wal' --exclude '*.db-shm'`) — never ship a hot WAL file;
- rebuild the derived index on the far side via `exec_remote`, or snapshot (`VACUUM INTO`) + transfer if authoritative;
- `BatchMode=yes` via `--ssh-opts` for non-interactive cron.

Example:
```
scitex-ssh sync ~/.scitex/scholar/library/ spartan:~/.scitex/scholar/library/ \
    --exclude index.db --exclude '*.db-wal' --exclude '*.db-shm' --ssh-opts '-o BatchMode=yes'
```

## Test plan
- [x] `sync_dir` argv shape (flags order, remote end placement) for push and pull
- [x] each `--exclude` rendered as `--exclude=<pat>`; `--delete` present only when requested
- [x] `ssh_opts` wired as `-e 'ssh <opts>'`; `extra_opts` appended verbatim; bad `direction` raises `ValueError`
- [x] CLI: dry-run, direction inference, local↔local & remote↔remote rejected, rsync invoked once, returncode propagated
- [x] Full suite green: 52 passed