### PR TITLE
chore(release): v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-03
+
 ### Added
 
+- `sync_dir()` primitive: one-way rsync-over-ssh directory sync
+  (`rsync -a --partial`) with caller-supplied exclude globs, optional
+  `--delete`, extra rsync flags, and `ssh_opts` wired via `-e`.
+  Policy-free by design — callers own excludes and any post-sync step.
+  Exposed as `scitex-ssh sync SRC DEST` (push/pull inferred from which
+  side is `HOST:PATH`). Enables cross-machine sync of per-user dirs such
+  as `~/.scitex/scholar/library` without shipping a live sqlite index.
 - `_allowlist`: honour the `$SCITEX_SSH_CONFIG` environment variable as a
   config-path override (resolved per-call via the new `config_path()`),
   matching the precedence chain already advertised in the CLI `--help` and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-ssh"
-version = "1.0.1"
+version = "1.1.0"
 description = "SSH primitives for SciTeX (exec/copy/attach/tunnel; per-host allowlist)"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump 1.0.1 → 1.1.0 and CHANGELOG for the sync_dir release (PR #43). Tag v1.1.0 follows once this merges; the tag pipeline publishes to PyPI and syncs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)