### PR TITLE
feat(tunnel): add `tunnel forward --discovery` — discovery-driven forward tunnel

### DIFF
--- a/src/scitex_ssh/_cli/_main.py
+++ b/src/scitex_ssh/_cli/_main.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
-"""Main CLI entry point for scitex-ssh."""
-
-import socket
+"""Main CLI entry point for scitex-ssh (root group + command registration)."""
 
 import click
 
 from ._introspect import list_python_apis
 from ._mcp import mcp
 from ._primitives import attach_cmd, copy_cmd, exec_cmd, sync_cmd
+from ._tunnel import (
+    _default_host,
+    _deprecation_warn,
+    _do_tunnel_remove,
+    _do_tunnel_setup,
+    _do_tunnel_status,
+    tunnel,
+)
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
@@ -91,23 +97,6 @@ def _get_version():
     return __version__
 
 
-def _default_host() -> str:
-    return socket.gethostname().split(".")[0]
-
-
-def _read_profile_arg(profile: str) -> str:
-    """Resolve a --profile value: inline JSON, ``@PATH`` for a file, or ``-``
-    for stdin."""
-    import sys
-
-    if profile == "-":
-        return sys.stdin.read()
-    if profile.startswith("@"):
-        with open(profile[1:]) as fh:
-            return fh.read()
-    return profile
-
-
 @click.group(
     cls=CategorizedGroup,
     invoke_without_command=True,
@@ -144,251 +133,8 @@ def main(ctx, version, help_recursive, as_json):
 
 
 # -----------------------------------------------------------------------
-# Tunnel subgroup
+# Deprecated top-level aliases (hidden) — thin wrappers over `tunnel *`
 # -----------------------------------------------------------------------
-
-
-@main.group("tunnel")
-def tunnel():
-    """Manage persistent SSH reverse tunnels (allowlist-gated)."""
-
-
-def _do_tunnel_setup(port, bastion, secret_key, host, *, setup_fn=None):
-    import scitex_ssh
-    from scitex_ssh._allowlist import PolicyError
-
-    if setup_fn is None:
-        setup_fn = scitex_ssh.setup
-    try:
-        result = setup_fn(port, bastion, secret_key, host=host)
-    except PolicyError as e:
-        click.secho(f"ERROR: {e}", fg="red", err=True)
-        raise SystemExit(2)
-    except ValueError as e:
-        click.secho(f"ERROR: {e}", fg="red", err=True)
-        raise SystemExit(1)
-    if result["success"]:
-        click.secho(f"Tunnel on port {port} set up successfully.", fg="green")
-        if result["stdout"]:
-            click.echo(result["stdout"])
-    else:
-        click.secho(f"Failed to set up tunnel on port {port}.", fg="red", err=True)
-        if result["stderr"]:
-            click.echo(result["stderr"], err=True)
-        raise SystemExit(1)
-
-
-def _do_tunnel_remove(port, host, *, remove_fn=None):
-    import scitex_ssh
-    from scitex_ssh._allowlist import PolicyError
-
-    if remove_fn is None:
-        remove_fn = scitex_ssh.remove
-    try:
-        result = remove_fn(port, host=host)
-    except PolicyError as e:
-        click.secho(f"ERROR: {e}", fg="red", err=True)
-        raise SystemExit(2)
-    if result["success"]:
-        click.secho(f"Tunnel on port {port} removed.", fg="green")
-        if result["stdout"]:
-            click.echo(result["stdout"])
-    else:
-        click.secho(f"Failed to remove tunnel on port {port}.", fg="red", err=True)
-        if result["stderr"]:
-            click.echo(result["stderr"], err=True)
-        raise SystemExit(1)
-
-
-def _do_tunnel_status(port, *, status_fn=None):
-    import scitex_ssh
-
-    if status_fn is None:
-        status_fn = scitex_ssh.status
-    result = status_fn(port)
-    click.echo(result["stdout"])
-    if result["stderr"]:
-        click.echo(result["stderr"], err=True)
-
-
-@tunnel.command("setup")
-@click.option("-p", "--port", required=True, type=int, help="Remote port to forward.")
-@click.option(
-    "-b",
-    "--bastion",
-    default=None,
-    help="Bastion server hostname or IP. [env: SCITEX_SSH_BASTION_SERVER]",
-)
-@click.option(
-    "-s",
-    "--secret-key",
-    default=None,
-    help="Path to SSH private key. [env: SCITEX_SSH_SECRET_KEY_PATH]",
-)
-@click.option(
-    "--host",
-    default=None,
-    help="Local host label for allowlist gating (default: local hostname).",
-)
-@click.option("--dry-run", is_flag=True, help="Print plan without setting up tunnel.")
-@click.option(
-    "-y", "--yes", is_flag=True, help="Suppress interactive confirmation (assume yes)."
-)
-def tunnel_setup(port, bastion, secret_key, host, dry_run, yes):
-    """Set up a persistent SSH reverse tunnel.
-
-    \b
-    Example:
-      $ scitex-ssh tunnel setup -p 8080 -b bastion.example.com
-      $ scitex-ssh tunnel setup -p 8080 --dry-run
-    """
-    if dry_run:
-        click.echo(
-            f"DRY RUN — would set up SSH reverse tunnel "
-            f"(port={port}, bastion={bastion}, host={host or _default_host()})"
-        )
-        return
-    _do_tunnel_setup(port, bastion, secret_key, host or _default_host())
-
-
-@tunnel.command("remove")
-@click.option("-p", "--port", required=True, type=int, help="Port of tunnel to remove.")
-@click.option(
-    "--host",
-    default=None,
-    help="Local host label for allowlist gating (default: local hostname).",
-)
-@click.option("--dry-run", is_flag=True, help="Print plan without removing tunnel.")
-@click.option(
-    "-y", "--yes", is_flag=True, help="Suppress interactive confirmation (assume yes)."
-)
-def tunnel_remove(port, host, dry_run, yes):
-    """Remove a persistent SSH reverse tunnel.
-
-    \b
-    Example:
-      $ scitex-ssh tunnel remove -p 8080
-      $ scitex-ssh tunnel remove -p 8080 --dry-run
-    """
-    if dry_run:
-        click.echo(
-            f"DRY RUN — would remove tunnel (port={port}, host={host or _default_host()})"
-        )
-        return
-    _do_tunnel_remove(port, host or _default_host())
-
-
-@tunnel.command("check-status")
-@click.option(
-    "-p",
-    "--port",
-    type=int,
-    default=None,
-    help="Specific port to check (default: all).",
-)
-@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
-def tunnel_status(port, as_json):
-    """Check status of SSH reverse tunnels (informational; not gated).
-
-    \b
-    Example:
-      $ scitex-ssh tunnel check-status
-      $ scitex-ssh tunnel check-status -p 8080
-      $ scitex-ssh tunnel check-status --json
-    """
-    if as_json:
-        import json as _json
-
-        import scitex_ssh
-
-        result = scitex_ssh.status(port)
-        click.echo(
-            _json.dumps(
-                {
-                    "port": port,
-                    "stdout": result.get("stdout", ""),
-                    "stderr": result.get("stderr", ""),
-                },
-                indent=2,
-            )
-        )
-        return
-    _do_tunnel_status(port)
-
-
-@tunnel.command("status", hidden=True)
-@click.option("-p", "--port", type=int, default=None)
-@click.option("--json", "as_json", is_flag=True)
-@click.pass_context
-def tunnel_status_deprecated(ctx, port, as_json):
-    """(deprecated) Use `tunnel check-status`."""
-    _deprecation_warn("tunnel status", "tunnel check-status")
-    ctx.invoke(tunnel_status, port=port, as_json=as_json)
-
-
-@tunnel.command("render-argv")
-@click.option(
-    "--profile",
-    required=True,
-    help="Tunnel spec as JSON. Inline, or @PATH to read a file, or - for stdin.",
-)
-@click.option(
-    "--as-json",
-    "as_json",
-    is_flag=True,
-    help="Emit the argv array as JSON instead of a shell-ready string.",
-)
-def tunnel_render_argv(profile, as_json):
-    """Render an ssh forward/reverse tunnel command from a JSON spec.
-
-    \b
-    Prints a single shell-safe `ssh -N ...` line (the default) suitable to
-    drop into a keepalive supervisor's opaque, foreground-blocking command
-    field; or the argv array as JSON with --as-json. This is pure string
-    construction — it does NOT open any connection.
-
-    \b
-    Example:
-      $ scitex-ssh tunnel render-argv --profile '{"direction":"forward",
-          "listen":{"host":"127.0.0.1","port":4000},
-          "target":{"host":"spartan-gpu-a017","port":4000},"via":"spartan"}'
-      ssh -N -o ExitOnForwardFailure=yes ... -L 127.0.0.1:4000:spartan-gpu-a017:4000 spartan
-    """
-    import json as _json
-
-    from scitex_ssh._tunnel_render import TunnelSpec, render_argv, render_command
-
-    raw = _read_profile_arg(profile)
-    try:
-        data = _json.loads(raw)
-    except _json.JSONDecodeError as e:
-        click.secho(f"ERROR: --profile is not valid JSON: {e}", fg="red", err=True)
-        raise SystemExit(2)
-    try:
-        spec = TunnelSpec.from_dict(data)
-    except (ValueError, KeyError, TypeError) as e:
-        click.secho(f"ERROR: invalid tunnel profile: {e}", fg="red", err=True)
-        raise SystemExit(2)
-
-    if as_json:
-        click.echo(_json.dumps(render_argv(spec)))
-    else:
-        click.echo(render_command(spec))
-
-
-# -----------------------------------------------------------------------
-# Deprecated top-level aliases (hidden)
-# -----------------------------------------------------------------------
-
-
-def _deprecation_warn(old: str, new: str) -> None:
-    click.secho(
-        f"warning: `scitex-ssh {old}` is deprecated; use `scitex-ssh {new}`.",
-        fg="yellow",
-        err=True,
-    )
-
-
 @main.command("setup-tunnel", hidden=True)
 @click.option("-p", "--port", required=True, type=int)
 @click.option("-b", "--bastion", default=None)
@@ -418,9 +164,9 @@ def show_status_deprecated(port):
 
 
 # -----------------------------------------------------------------------
-# Register top-level primitive + integration commands
+# Register command groups (tunnel) + top-level primitives + integration
 # -----------------------------------------------------------------------
-
+main.add_command(tunnel)
 main.add_command(exec_cmd)
 main.add_command(copy_cmd)
 main.add_command(sync_cmd)

--- a/src/scitex_ssh/_cli/_tunnel.py
+++ b/src/scitex_ssh/_cli/_tunnel.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""`scitex-ssh tunnel` command group — reverse tunnels + argv/forward tooling.
+
+Extracted from ``_main.py`` (SoC: root CLI vs tunnel domain). Holds the
+`tunnel` click group and every subcommand:
+
+  * ``setup`` / ``remove`` / ``check-status`` — persistent reverse tunnel
+    lifecycle (allowlist-gated autossh+systemd).
+  * ``render-argv`` — pure ssh -L/-R argv rendering from a JSON spec.
+  * ``forward`` — discovery-driven forward tunnel (exec a blocking ssh).
+
+The shared helpers (`_default_host`, `_read_profile_arg`, `_deprecation_warn`,
+`_do_tunnel_*`) live here and are imported back by ``_main`` for the
+deprecated top-level aliases.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import click
+
+
+def _default_host() -> str:
+    return socket.gethostname().split(".")[0]
+
+
+def _read_profile_arg(profile: str) -> str:
+    """Resolve a --profile value: inline JSON, ``@PATH`` for a file, or ``-``
+    for stdin."""
+    import sys
+
+    if profile == "-":
+        return sys.stdin.read()
+    if profile.startswith("@"):
+        with open(profile[1:]) as fh:
+            return fh.read()
+    return profile
+
+
+def _deprecation_warn(old: str, new: str) -> None:
+    click.secho(
+        f"warning: `scitex-ssh {old}` is deprecated; use `scitex-ssh {new}`.",
+        fg="yellow",
+        err=True,
+    )
+
+
+# -----------------------------------------------------------------------
+# Reverse-tunnel action helpers (call the production functions)
+# -----------------------------------------------------------------------
+def _do_tunnel_setup(port, bastion, secret_key, host, *, setup_fn=None):
+    import scitex_ssh
+    from scitex_ssh._allowlist import PolicyError
+
+    if setup_fn is None:
+        setup_fn = scitex_ssh.setup
+    try:
+        result = setup_fn(port, bastion, secret_key, host=host)
+    except PolicyError as e:
+        click.secho(f"ERROR: {e}", fg="red", err=True)
+        raise SystemExit(2)
+    except ValueError as e:
+        click.secho(f"ERROR: {e}", fg="red", err=True)
+        raise SystemExit(1)
+    if result["success"]:
+        click.secho(f"Tunnel on port {port} set up successfully.", fg="green")
+        if result["stdout"]:
+            click.echo(result["stdout"])
+    else:
+        click.secho(f"Failed to set up tunnel on port {port}.", fg="red", err=True)
+        if result["stderr"]:
+            click.echo(result["stderr"], err=True)
+        raise SystemExit(1)
+
+
+def _do_tunnel_remove(port, host, *, remove_fn=None):
+    import scitex_ssh
+    from scitex_ssh._allowlist import PolicyError
+
+    if remove_fn is None:
+        remove_fn = scitex_ssh.remove
+    try:
+        result = remove_fn(port, host=host)
+    except PolicyError as e:
+        click.secho(f"ERROR: {e}", fg="red", err=True)
+        raise SystemExit(2)
+    if result["success"]:
+        click.secho(f"Tunnel on port {port} removed.", fg="green")
+        if result["stdout"]:
+            click.echo(result["stdout"])
+    else:
+        click.secho(f"Failed to remove tunnel on port {port}.", fg="red", err=True)
+        if result["stderr"]:
+            click.echo(result["stderr"], err=True)
+        raise SystemExit(1)
+
+
+def _do_tunnel_status(port, *, status_fn=None):
+    import scitex_ssh
+
+    if status_fn is None:
+        status_fn = scitex_ssh.status
+    result = status_fn(port)
+    click.echo(result["stdout"])
+    if result["stderr"]:
+        click.echo(result["stderr"], err=True)
+
+
+# -----------------------------------------------------------------------
+# tunnel group
+# -----------------------------------------------------------------------
+@click.group("tunnel")
+def tunnel():
+    """Manage SSH tunnels (reverse lifecycle + argv/forward tooling)."""
+
+
+@tunnel.command("setup")
+@click.option("-p", "--port", required=True, type=int, help="Remote port to forward.")
+@click.option(
+    "-b",
+    "--bastion",
+    default=None,
+    help="Bastion server hostname or IP. [env: SCITEX_SSH_BASTION_SERVER]",
+)
+@click.option(
+    "-s",
+    "--secret-key",
+    default=None,
+    help="Path to SSH private key. [env: SCITEX_SSH_SECRET_KEY_PATH]",
+)
+@click.option(
+    "--host",
+    default=None,
+    help="Local host label for allowlist gating (default: local hostname).",
+)
+@click.option("--dry-run", is_flag=True, help="Print plan without setting up tunnel.")
+@click.option(
+    "-y", "--yes", is_flag=True, help="Suppress interactive confirmation (assume yes)."
+)
+def tunnel_setup(port, bastion, secret_key, host, dry_run, yes):
+    """Set up a persistent SSH reverse tunnel.
+
+    \b
+    Example:
+      $ scitex-ssh tunnel setup -p 8080 -b bastion.example.com
+      $ scitex-ssh tunnel setup -p 8080 --dry-run
+    """
+    if dry_run:
+        click.echo(
+            f"DRY RUN — would set up SSH reverse tunnel "
+            f"(port={port}, bastion={bastion}, host={host or _default_host()})"
+        )
+        return
+    _do_tunnel_setup(port, bastion, secret_key, host or _default_host())
+
+
+@tunnel.command("remove")
+@click.option("-p", "--port", required=True, type=int, help="Port of tunnel to remove.")
+@click.option(
+    "--host",
+    default=None,
+    help="Local host label for allowlist gating (default: local hostname).",
+)
+@click.option("--dry-run", is_flag=True, help="Print plan without removing tunnel.")
+@click.option(
+    "-y", "--yes", is_flag=True, help="Suppress interactive confirmation (assume yes)."
+)
+def tunnel_remove(port, host, dry_run, yes):
+    """Remove a persistent SSH reverse tunnel.
+
+    \b
+    Example:
+      $ scitex-ssh tunnel remove -p 8080
+      $ scitex-ssh tunnel remove -p 8080 --dry-run
+    """
+    if dry_run:
+        click.echo(
+            f"DRY RUN — would remove tunnel (port={port}, host={host or _default_host()})"
+        )
+        return
+    _do_tunnel_remove(port, host or _default_host())
+
+
+@tunnel.command("check-status")
+@click.option(
+    "-p",
+    "--port",
+    type=int,
+    default=None,
+    help="Specific port to check (default: all).",
+)
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def tunnel_status(port, as_json):
+    """Check status of SSH reverse tunnels (informational; not gated).
+
+    \b
+    Example:
+      $ scitex-ssh tunnel check-status
+      $ scitex-ssh tunnel check-status -p 8080
+      $ scitex-ssh tunnel check-status --json
+    """
+    if as_json:
+        import json as _json
+
+        import scitex_ssh
+
+        result = scitex_ssh.status(port)
+        click.echo(
+            _json.dumps(
+                {
+                    "port": port,
+                    "stdout": result.get("stdout", ""),
+                    "stderr": result.get("stderr", ""),
+                },
+                indent=2,
+            )
+        )
+        return
+    _do_tunnel_status(port)
+
+
+@tunnel.command("status", hidden=True)
+@click.option("-p", "--port", type=int, default=None)
+@click.option("--json", "as_json", is_flag=True)
+@click.pass_context
+def tunnel_status_deprecated(ctx, port, as_json):
+    """(deprecated) Use `tunnel check-status`."""
+    _deprecation_warn("tunnel status", "tunnel check-status")
+    ctx.invoke(tunnel_status, port=port, as_json=as_json)
+
+
+@tunnel.command("render-argv")
+@click.option(
+    "--profile",
+    required=True,
+    help="Tunnel spec as JSON. Inline, or @PATH to read a file, or - for stdin.",
+)
+@click.option(
+    "--as-json",
+    "as_json",
+    is_flag=True,
+    help="Emit the argv array as JSON instead of a shell-ready string.",
+)
+def tunnel_render_argv(profile, as_json):
+    """Render an ssh forward/reverse tunnel command from a JSON spec.
+
+    \b
+    Prints a single shell-safe `ssh -N ...` line (the default) suitable to
+    drop into a keepalive supervisor's opaque, foreground-blocking command
+    field; or the argv array as JSON with --as-json. This is pure string
+    construction — it does NOT open any connection.
+
+    \b
+    Example:
+      $ scitex-ssh tunnel render-argv --profile '{"direction":"forward",
+          "listen":{"host":"127.0.0.1","port":4000},
+          "target":{"host":"spartan-gpu-a017","port":4000},"via":"spartan"}'
+      ssh -N -o ExitOnForwardFailure=yes ... -L 127.0.0.1:4000:spartan-gpu-a017:4000 spartan
+    """
+    import json as _json
+
+    from scitex_ssh._tunnel_render import TunnelSpec, render_argv, render_command
+
+    raw = _read_profile_arg(profile)
+    try:
+        data = _json.loads(raw)
+    except _json.JSONDecodeError as e:
+        click.secho(f"ERROR: --profile is not valid JSON: {e}", fg="red", err=True)
+        raise SystemExit(2)
+    try:
+        spec = TunnelSpec.from_dict(data)
+    except (ValueError, KeyError, TypeError) as e:
+        click.secho(f"ERROR: invalid tunnel profile: {e}", fg="red", err=True)
+        raise SystemExit(2)
+
+    if as_json:
+        click.echo(_json.dumps(render_argv(spec)))
+    else:
+        click.echo(render_command(spec))
+
+
+@tunnel.command("forward")
+@click.option(
+    "--discovery",
+    required=True,
+    help="Path to the endpoint discovery JSON file (read fresh on each launch).",
+)
+@click.option(
+    "--via",
+    default="spartan",
+    show_default=True,
+    help="Stable SSH login alias to connect to (the discovery node resolves on ITS network).",
+)
+@click.option("--via-user", default=None, help="SSH user for --via.")
+@click.option("--via-port", type=int, default=None, help="SSH port for --via.")
+@click.option(
+    "--local-host", default="127.0.0.1", show_default=True, help="Local bind host."
+)
+@click.option(
+    "--local-port",
+    type=int,
+    default=None,
+    help="Local bind port (default: same as the resolved remote port).",
+)
+@click.option(
+    "--remote-port",
+    type=int,
+    default=None,
+    help="Remote port to reach (default: read --port-field from discovery).",
+)
+@click.option(
+    "--port-field",
+    type=click.Choice(["litellm_port", "vllm_port"]),
+    default="litellm_port",
+    show_default=True,
+    help="Which discovery-file port field to tunnel when --remote-port is unset.",
+)
+@click.option("--identity", default=None, help="SSH private key path (-i).")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Print the resolved ssh command and exit, without connecting.",
+)
+def tunnel_forward(
+    discovery,
+    via,
+    via_user,
+    via_port,
+    local_host,
+    local_port,
+    remote_port,
+    port_field,
+    identity,
+    dry_run,
+):
+    """Open a forward tunnel to a service whose host is published in a discovery file.
+
+    \b
+    Reads --discovery FRESH, builds `ssh -N -L <local>:<node>:<remote>` (node
+    from the file), and REPLACES this process with that blocking ssh. Designed
+    to run as a keepalive supervisor's foreground command: because the file is
+    re-read on every launch, each supervisor relaunch re-points to the current
+    node — the restart IS the re-point (no loop here).
+
+    \b
+    Example (as a supervisor command for the ephemeral qwen node):
+      $ scitex-ssh tunnel forward --discovery /data/.../qwen-endpoint.json
+      $ scitex-ssh tunnel forward --discovery ./qwen-endpoint.json --dry-run
+    """
+    from scitex_ssh._tunnel_forward import (
+        DiscoveryError,
+        exec_forward,
+        forward_command,
+        resolve_forward_spec,
+    )
+
+    try:
+        spec = resolve_forward_spec(
+            discovery,
+            via=via,
+            via_user=via_user,
+            via_port=via_port,
+            local_host=local_host,
+            local_port=local_port,
+            remote_port=remote_port,
+            port_field=port_field,
+            identity=identity,
+        )
+    except DiscoveryError as e:
+        click.secho(f"ERROR: {e}", fg="red", err=True)
+        raise SystemExit(1)
+
+    if dry_run:
+        click.echo(forward_command(spec))
+        return
+    exec_forward(spec)  # replaces the process; never returns on success
+
+
+# EOF

--- a/src/scitex_ssh/_tunnel_forward.py
+++ b/src/scitex_ssh/_tunnel_forward.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Discovery-driven forward tunnel: read an endpoint file, exec a blocking ssh.
+
+This is the client-side half of the qwen cross-host reachability seam agreed
+with scitex-hpc. A service (e.g. qwen/LiteLLM) runs on an EPHEMERAL Spartan
+compute node whose hostname changes on every reschedule; scitex-hpc publishes
+a discovery JSON on Spartan shared storage and rewrites it on each (re)launch:
+
+    {"node": "spartan-gpgpu014", "litellm_port": 4000, "vllm_port": 8765,
+     "model": "qwen36-35b-a3b", "key": "sk-clew-local", "updated_at": "<ISO>"}
+
+`resolve_forward_spec` reads that file FRESH and builds a
+:class:`~scitex_ssh._tunnel_render.TunnelSpec` for a forward tunnel:
+
+    ssh -N -L <local_host>:<local_port>:<node>:<remote_port> <via>
+
+with ``via`` a STABLE login alias (e.g. ``spartan``) — the ephemeral ``node``
+resolves on the login host's internal network (verified reachable by
+scitex-hpc: ``curl http://<node>:4000/v1/models`` from the login node).
+
+Re-pointing is intentionally NOT a loop here. scitex-hpc's generic
+tunnel-supervisor owns keepalive: it runs ``scitex-ssh tunnel forward
+--discovery <path>`` as an opaque, foreground-blocking ``command`` and
+relaunches it on exit / endpoint-health failure. Because THIS command
+re-reads the discovery file every time it starts, each supervisor relaunch
+picks up the current ``node`` — so the supervisor's restart IS the re-point.
+Hence :func:`exec_forward` uses ``os.execvp`` (replace the process, block,
+propagate signals) rather than spawning a child or looping.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
+from ._tunnel_render import Endpoint, TunnelSpec, render_argv, render_command
+
+# Discovery-file keys that name a port. Kept as an explicit allowlist so a
+# typo'd --port-field fails loudly instead of tunnelling an arbitrary field.
+PORT_FIELDS = ("litellm_port", "vllm_port")
+
+DEFAULT_VIA = "spartan"
+DEFAULT_LOCAL_HOST = "127.0.0.1"
+DEFAULT_PORT_FIELD = "litellm_port"
+
+
+class DiscoveryError(RuntimeError):
+    """Raised when the discovery file is missing, unparseable, or incomplete."""
+
+
+def load_discovery(discovery_path: str) -> dict:
+    """Read and parse the discovery JSON file.
+
+    Fails LOUD (raises :class:`DiscoveryError`) on a missing file or invalid
+    JSON — the supervisor treats a non-zero exit as "command died" and
+    relaunches, so a transient missing file self-heals once it appears.
+    """
+    try:
+        with open(discovery_path) as fh:
+            raw = fh.read()
+    except OSError as exc:
+        raise DiscoveryError(
+            f"discovery file unreadable: {discovery_path} ({exc})"
+        ) from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise DiscoveryError(
+            f"discovery file is not valid JSON: {discovery_path} ({exc})"
+        ) from exc
+    if not isinstance(data, dict):
+        raise DiscoveryError(
+            f"discovery file must be a JSON object, got {type(data).__name__}"
+        )
+    return data
+
+
+def resolve_forward_spec(
+    discovery_path: str,
+    *,
+    via: str = DEFAULT_VIA,
+    via_user: Optional[str] = None,
+    via_port: Optional[int] = None,
+    local_host: str = DEFAULT_LOCAL_HOST,
+    local_port: Optional[int] = None,
+    remote_port: Optional[int] = None,
+    port_field: str = DEFAULT_PORT_FIELD,
+    identity: Optional[str] = None,
+) -> TunnelSpec:
+    """Build a forward :class:`TunnelSpec` from the discovery file.
+
+    ``remote_port`` (if given) wins over ``port_field``; ``local_port``
+    defaults to the resolved remote port (so ``127.0.0.1:4000`` maps to the
+    node's 4000 by default).
+    """
+    if port_field not in PORT_FIELDS:
+        raise DiscoveryError(
+            f"unknown port_field {port_field!r}; expected one of {PORT_FIELDS}"
+        )
+    data = load_discovery(discovery_path)
+
+    node = data.get("node")
+    if not node:
+        raise DiscoveryError("discovery file missing required key 'node'")
+
+    if remote_port is not None:
+        rport = int(remote_port)
+    else:
+        if port_field not in data:
+            raise DiscoveryError(
+                f"discovery file missing port field {port_field!r} "
+                f"(and no --remote-port given)"
+            )
+        rport = int(data[port_field])
+
+    lport = int(local_port) if local_port is not None else rport
+
+    return TunnelSpec(
+        direction="forward",
+        listen=Endpoint(local_host, lport),
+        target=Endpoint(str(node), rport),
+        via=via,
+        via_user=via_user,
+        via_port=via_port,
+        identity=identity,
+    )
+
+
+def exec_forward(spec: TunnelSpec) -> "None":  # pragma: no cover - replaces process
+    """Replace the current process with the blocking ``ssh`` for ``spec``.
+
+    Never returns on success (``os.execvp`` overlays the process image). This
+    is what makes the command a proper foreground-blocking ``command`` for
+    scitex-hpc's supervisor loop.
+    """
+    argv = render_argv(spec)
+    os.execvp(argv[0], argv)
+
+
+def forward_command(spec: TunnelSpec) -> str:
+    """Return the ssh command string that :func:`exec_forward` would run
+    (used by ``--dry-run`` and for putting into a supervisor profile)."""
+    return render_command(spec)
+
+
+# EOF

--- a/tests/scitex_ssh/_cli/test__main.py
+++ b/tests/scitex_ssh/_cli/test__main.py
@@ -503,4 +503,60 @@ class TestTunnelRenderArgv:
         assert "invalid tunnel profile" in result.output
 
 
+class TestTunnelForward:
+    """`tunnel forward`: discovery-file -> ssh forward command (via --dry-run)."""
+
+    _DISCOVERY = {
+        "node": "spartan-gpgpu014",
+        "litellm_port": 4000,
+        "vllm_port": 8765,
+        "model": "qwen36-35b-a3b",
+        "key": "sk-clew-local",
+    }
+
+    def _write(self, tmp_path):
+        p = tmp_path / "qwen-endpoint.json"
+        p.write_text(json.dumps(self._DISCOVERY))
+        return str(p)
+
+    def test_dry_run_exits_zero(self, tmp_path):
+        # Arrange
+        runner = CliRunner()
+        path = self._write(tmp_path)
+        # Act
+        result = runner.invoke(main, ["tunnel", "forward", "--discovery", path, "--dry-run"])
+        # Assert
+        assert result.exit_code == 0
+
+    def test_dry_run_renders_node_from_discovery(self, tmp_path):
+        # Arrange
+        runner = CliRunner()
+        path = self._write(tmp_path)
+        # Act
+        result = runner.invoke(main, ["tunnel", "forward", "--discovery", path, "--dry-run"])
+        # Assert
+        assert "-L 127.0.0.1:4000:spartan-gpgpu014:4000" in result.output
+
+    def test_dry_run_uses_via_as_destination(self, tmp_path):
+        # Arrange
+        runner = CliRunner()
+        path = self._write(tmp_path)
+        # Act
+        result = runner.invoke(
+            main,
+            ["tunnel", "forward", "--discovery", path, "--via", "spartan", "--dry-run"],
+        )
+        # Assert
+        assert result.output.strip().endswith(" spartan")
+
+    def test_missing_discovery_file_exits_1(self, tmp_path):
+        # Arrange
+        runner = CliRunner()
+        missing = str(tmp_path / "nope.json")
+        # Act
+        result = runner.invoke(main, ["tunnel", "forward", "--discovery", missing, "--dry-run"])
+        # Assert
+        assert result.exit_code == 1
+
+
 # EOF

--- a/tests/scitex_ssh/test__tunnel_forward.py
+++ b/tests/scitex_ssh/test__tunnel_forward.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Tests for scitex_ssh._tunnel_forward — discovery-driven forward tunnel spec.
+
+No mocks: discovery files are written to a real tmp_path and read back. The
+process-replacing exec_forward is not unit-tested (it overlays the process);
+resolution + rendering + error paths are, which is where the logic lives.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scitex_ssh._tunnel_forward import (
+    DiscoveryError,
+    forward_command,
+    load_discovery,
+    resolve_forward_spec,
+)
+from scitex_ssh._tunnel_render import render_argv, render_command
+
+_DISCOVERY = {
+    "node": "spartan-gpgpu014",
+    "litellm_port": 4000,
+    "vllm_port": 8765,
+    "model": "qwen36-35b-a3b",
+    "key": "sk-clew-local",
+    "updated_at": "2026-07-05T17:00:00Z",
+}
+
+
+def _write_discovery(tmp_path, data=None) -> str:
+    """Write a discovery JSON file and return its path."""
+    p = tmp_path / "qwen-endpoint.json"
+    p.write_text(json.dumps(_DISCOVERY if data is None else data))
+    return str(p)
+
+
+class TestResolveForwardSpec:
+    def test_direction_is_forward(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path)
+        # Act
+        spec = resolve_forward_spec(path)
+        # Assert
+        assert spec.direction == "forward"
+
+    def test_target_host_is_discovery_node(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path)
+        # Act
+        spec = resolve_forward_spec(path)
+        # Assert
+        assert spec.target.host == "spartan-gpgpu014"
+
+    def test_target_port_from_litellm_field(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path)
+        # Act
+        spec = resolve_forward_spec(path)
+        # Assert
+        assert spec.target.port == 4000
+
+    def test_local_port_defaults_to_remote(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path)
+        # Act
+        spec = resolve_forward_spec(path)
+        # Assert
+        assert spec.listen.port == 4000
+
+    def test_via_is_destination_and_last_arg(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path)
+        # Act
+        argv = render_argv(resolve_forward_spec(path, via="spartan"))
+        # Assert
+        assert argv[-1] == "spartan"
+
+    def test_remote_port_override_wins(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path)
+        # Act
+        spec = resolve_forward_spec(path, remote_port=9999)
+        # Assert
+        assert spec.target.port == 9999
+
+    def test_vllm_port_field_selects_vllm_port(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path)
+        # Act
+        spec = resolve_forward_spec(path, port_field="vllm_port")
+        # Assert
+        assert spec.target.port == 8765
+
+    def test_custom_local_port_is_used(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path)
+        # Act
+        spec = resolve_forward_spec(path, local_port=4100)
+        # Assert
+        assert spec.listen.port == 4100
+
+    def test_forward_command_matches_render_command(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path)
+        spec = resolve_forward_spec(path)
+        # Act
+        cmd = forward_command(spec)
+        # Assert
+        assert cmd == render_command(spec)
+
+
+class TestDiscoveryErrors:
+    def test_missing_file_raises(self, tmp_path):
+        # Arrange
+        missing = str(tmp_path / "nope.json")
+        # Act
+        ctx = pytest.raises(DiscoveryError, match="unreadable")
+        # Assert
+        with ctx:
+            load_discovery(missing)
+
+    def test_invalid_json_raises(self, tmp_path):
+        # Arrange
+        p = tmp_path / "bad.json"
+        p.write_text("{not json")
+        # Act
+        ctx = pytest.raises(DiscoveryError, match="not valid JSON")
+        # Assert
+        with ctx:
+            load_discovery(str(p))
+
+    def test_non_object_json_raises(self, tmp_path):
+        # Arrange
+        p = tmp_path / "arr.json"
+        p.write_text("[1, 2, 3]")
+        # Act
+        ctx = pytest.raises(DiscoveryError, match="JSON object")
+        # Assert
+        with ctx:
+            load_discovery(str(p))
+
+    def test_missing_node_raises(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path, {"litellm_port": 4000})
+        # Act
+        ctx = pytest.raises(DiscoveryError, match="node")
+        # Assert
+        with ctx:
+            resolve_forward_spec(path)
+
+    def test_missing_port_field_raises(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path, {"node": "n"})
+        # Act
+        ctx = pytest.raises(DiscoveryError, match="port field")
+        # Assert
+        with ctx:
+            resolve_forward_spec(path)
+
+    def test_unknown_port_field_raises(self, tmp_path):
+        # Arrange
+        path = _write_discovery(tmp_path)
+        # Act
+        ctx = pytest.raises(DiscoveryError, match="unknown port_field")
+        # Assert
+        with ctx:
+            resolve_forward_spec(path, port_field="bogus_port")
+
+
+# EOF


### PR DESCRIPTION
## What

Adds `scitex-ssh tunnel forward --discovery <path>` — the client-side half of the qwen cross-host reachability seam with scitex-hpc. Reads an endpoint discovery JSON **fresh**, builds `ssh -N -L <local>:<node>:<remote> <via>`, and **replaces the process** with that blocking ssh (`os.execvp`).

Completes card `ssh-forward-tunnel-daemon` (the `render-argv` half shipped in #45; scitex-hpc's supervisor primitive merged in scitex-hpc#39).

## How it composes (SoC with scitex-hpc)

- **scitex-hpc's** generic tunnel-supervisor owns keepalive: it runs this command as an opaque, foreground-blocking `command` and relaunches on exit / endpoint-health failure.
- This command **does not loop**. Because it re-reads the discovery file on every launch, each supervisor relaunch re-points to the current `node` — **the restart IS the re-point**. Hence `os.execvp` (block, propagate signals) rather than a child process or a watch loop.
- Fails **loud**: missing/invalid/incomplete discovery → `DiscoveryError` → exit 1, so the supervisor retries and self-heals once the file appears.

## Discovery contract (firm, from scitex-hpc)

```json
{"node": "spartan-gpgpu014", "litellm_port": 4000, "vllm_port": 8765,
 "model": "qwen36-35b-a3b", "key": "sk-clew-local", "updated_at": "<ISO>"}
```

Resolved command (verified reachable login→node by scitex-hpc):

```
$ scitex-ssh tunnel forward --discovery ./qwen-endpoint.json --dry-run
ssh -N -o ExitOnForwardFailure=yes -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o StrictHostKeyChecking=accept-new -L 127.0.0.1:4000:spartan-gpgpu014:4000 spartan
```

Supervisor profile just carries: `command = "scitex-ssh tunnel forward --discovery /data/.../qwen-endpoint.json"`.

## CLI

`--via` (default `spartan`), `--via-user`, `--via-port`, `--local-host`, `--local-port` (default = remote port), `--remote-port`, `--port-field {litellm_port,vllm_port}`, `--identity`, `--dry-run` (print resolved command without connecting).

## Refactor included

`_cli/_main.py` exceeded the 512-line limit once `forward` landed on top of the merged `render-argv`, so the `tunnel` group + all subcommands moved to **`_cli/_tunnel.py`** (SoC). `_main.py` stays the thin root orchestrator and re-exports the moved helpers for import back-compat.

## Tests

- `tests/scitex_ssh/test__tunnel_forward.py` — resolution (node/port/local/via, remote-port + vllm-port overrides) and error paths (missing file, bad JSON, non-object, missing node/port-field, unknown field) against real temp discovery files.
- `tests/scitex_ssh/_cli/test__main.py::TestTunnelForward` — `--dry-run` render + missing-file exit 1.
- Verified locally via stdlib smoke (broken `.venv` on this host); full matrix runs in CI.