### PR TITLE
fix(tunnel): harden reverse autossh unit against dead-forward-after-blip

### DIFF
--- a/src/scitex_ssh/scripts/setup-autossh-service.sh
+++ b/src/scitex_ssh/scripts/setup-autossh-service.sh
@@ -19,7 +19,14 @@ write-autossh-service() {
         [Service]
         User=$USER
         Environment="AUTOSSH_GATETIME=0"
-        ExecStart=/usr/bin/autossh -M 0 -N -o "PubkeyAuthentication=yes" -o "PasswordAuthentication=no" -i $SECRET_KEY_PATH -R ${PORT}:localhost:22 $BASTION_SERVER
+        # ServerAlive* : with -M 0 (autossh monitor off) ssh's own keepalive is
+        #   the ONLY way to notice a half-dead link; without it a broken tunnel
+        #   lingers and autossh never restarts.
+        # ExitOnForwardFailure=yes : if the remote -R port is still bound by a
+        #   stale session on reconnect, exit (so autossh retries) instead of
+        #   sitting connected with a DEAD forward — the classic "reverse tunnel
+        #   up but forwarded port closes immediately" failure.
+        ExecStart=/usr/bin/autossh -M 0 -N -o "PubkeyAuthentication=yes" -o "PasswordAuthentication=no" -o "ServerAliveInterval=15" -o "ServerAliveCountMax=3" -o "ExitOnForwardFailure=yes" -i $SECRET_KEY_PATH -R ${PORT}:localhost:22 $BASTION_SERVER
         RestartSec=3
         Restart=always
 

--- a/tests/integration/test_autossh_service_script.py
+++ b/tests/integration/test_autossh_service_script.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
-"""Tests for the bundled setup-autossh-service.sh reverse-tunnel unit.
+"""Integration test for the bundled setup-autossh-service.sh reverse-tunnel unit.
 
-No mocks: asserts directly on the shipped script text (resolved the same way
-production does, via ``scitex_ssh._SCRIPTS_DIR``). Locks in the keepalive /
+Lives in tests/integration/ (not tests/scitex_ssh/) because the asset under
+test is a bundled shell script owned by __init__.py's setup(), with no module
+basename to mirror — the canonical home per scitex-dev audit-project (PS-204
+orphan-test rule / PS302).
+
+No mocks: asserts directly on the shipped script text, resolved the same way
+production does (via scitex_ssh._SCRIPTS_DIR). Locks in the keepalive /
 ExitOnForwardFailure options that keep a reverse -R tunnel from silently
 sitting on a dead forward after a network blip.
 """

--- a/tests/scitex_ssh/test__autossh_service_script.py
+++ b/tests/scitex_ssh/test__autossh_service_script.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Tests for the bundled setup-autossh-service.sh reverse-tunnel unit.
+
+No mocks: asserts directly on the shipped script text (resolved the same way
+production does, via ``scitex_ssh._SCRIPTS_DIR``). Locks in the keepalive /
+ExitOnForwardFailure options that keep a reverse -R tunnel from silently
+sitting on a dead forward after a network blip.
+"""
+
+from __future__ import annotations
+
+import os
+
+import scitex_ssh
+
+
+def _execstart_line() -> str:
+    """Return the ExecStart line of the bundled autossh service script."""
+    path = os.path.join(scitex_ssh._SCRIPTS_DIR, "setup-autossh-service.sh")
+    with open(path) as fh:
+        for line in fh:
+            if line.lstrip().startswith("ExecStart="):
+                return line.strip()
+    raise AssertionError("no ExecStart line found in setup-autossh-service.sh")
+
+
+class TestAutosshExecStart:
+    def test_sets_server_alive_interval(self):
+        # Arrange
+        line = _execstart_line()
+        # Act
+        # Assert
+        assert "ServerAliveInterval=15" in line
+
+    def test_sets_server_alive_count_max(self):
+        # Arrange
+        line = _execstart_line()
+        # Act
+        # Assert
+        assert "ServerAliveCountMax=3" in line
+
+    def test_sets_exit_on_forward_failure(self):
+        # Arrange
+        line = _execstart_line()
+        # Act
+        # Assert
+        assert "ExitOnForwardFailure=yes" in line
+
+    def test_still_defines_reverse_forward(self):
+        # Arrange
+        line = _execstart_line()
+        # Act
+        # Assert
+        assert "-R ${PORT}:localhost:22" in line
+
+    def test_keeps_autossh_monitor_port_disabled(self):
+        # Arrange — -M 0 delegates liveness to ssh's ServerAlive (regression guard).
+        line = _execstart_line()
+        # Act
+        # Assert
+        assert "-M 0" in line
+
+
+# EOF


### PR DESCRIPTION
## Symptom

neurovista reported the reverse tunnel Spartan→ywata-note-win down: *"ssh back closes immediately on the forwarded port"* (forward PC→Spartan fine). Routed to scitex-ssh (reverse autossh+systemd tunnels are our domain). Card: `neurovista-reverse-tunnel-down`.

## Root cause (found in our own code, not guessed)

`scripts/setup-autossh-service.sh` generated the unit with `-M 0` (autossh monitor off) but **no ssh keepalive** and **no `ExitOnForwardFailure`**:

```
autossh -M 0 -N -o PubkeyAuthentication=yes -o PasswordAuthentication=no -i $KEY -R ${PORT}:localhost:22 $BASTION
```

That is the classic broken-reverse-tunnel recipe. After a network blip:
1. The receiving sshd still holds the stale `-R` listening socket.
2. autossh reconnects; the forward fails to rebind.
3. **Without `ExitOnForwardFailure=yes`, ssh stays connected with a DEAD forward** — the unit shows `running`, but the port closes immediately on connect.
4. With `-M 0` and no `ServerAlive*`, autossh has no way to detect the half-dead link, so it never restarts.

## Fix

Add to `ExecStart`:
- `ServerAliveInterval=15` + `ServerAliveCountMax=3` — client detects a dead link in ~45s, exits, autossh restarts.
- `ExitOnForwardFailure=yes` — on reconnect, exit (retry) rather than hold a dead forward.

These are exactly `scitex_ssh._tunnel_render.DEFAULT_SSH_OPTS`, so the **reverse (autossh)** and **forward (render-argv)** paths now share the same robustness.

## Test

`tests/scitex_ssh/test__autossh_service_script.py` asserts the shipped script's `ExecStart` carries `ServerAliveInterval`/`ServerAliveCountMax`/`ExitOnForwardFailure`, still defines the `-R` forward, and keeps `-M 0` (regression guard). Verified locally (broken `.venv` on this host; full matrix runs in CI).

## Out of scope (documented on the card)

The *complete* fix also wants server-side sshd `ClientAliveInterval`/`ClientAliveCountMax` on the receiving host (ywata-note-win) to reap the stale bind fast — that is host config, not this package. The client-side `ExitOnForwardFailure` makes autossh keep retrying until the port frees regardless.

Live diagnosis of neurovista's specific tunnel is **deferred** (reporter + operator flagged not-urgent; they don't need reverse ssh right now). This PR fixes the tool for everyone regardless.