### PR TITLE
fix(ci): don't fetch into checked-out main in --new-only baseline step

### DIFF
--- a/.github/workflows/scitex-ssh-quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/scitex-ssh-quality-audit-on-ubuntu-latest.yml
@@ -41,7 +41,9 @@ jobs:
           python-version: "3.12"
 
       - name: Fetch main ref for --new-only baseline
-        run: git fetch origin main:main
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          git show-ref --verify --quiet refs/heads/main || git branch main origin/main
 
       - name: Install package + audit tooling
         run: |


### PR DESCRIPTION
## Problem

The `quality` workflow's **"Fetch main ref for --new-only baseline"** step runs:

```yaml
run: git fetch origin main:main
```

On the **scheduled nightly** (`cron: "0 18 * * *"`) and on **workflow_dispatch against the default branch**, `actions/checkout` lands on `main`. `git fetch origin main:main` then fails:

```
fatal: refusing to fetch into branch 'refs/heads/main' checked out at ...
```

→ exit 128, "All jobs have failed".

## Why only the nightly is red

- `push` is gated to `branches: [develop]` — never has `main` checked out.
- `pull_request` runs on a **detached** merge ref — not on `refs/heads/main`.

So PR runs and develop pushes were **always green**; only the schedule / dispatch runs (which check out `main`) hit the failure.

## Fix

Fetch only into a remote-tracking ref, and materialize a local `main` only when one does not already exist:

```yaml
run: |
  git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
  git show-ref --verify --quiet refs/heads/main || git branch main origin/main
```

- The fetch writes only `refs/remotes/origin/main`, so it never errors regardless of which branch is checked out.
- The `git branch` runs only when a local `main` does not already exist (skipped when `main` IS the checkout), so it never errors either.

Idempotent on every trigger (schedule / dispatch / push-develop / PR), and still guarantees a resolvable `main` for the `--new-only` baseline (`git show <ref>:<path>`). `actions/checkout` already uses `fetch-depth: 0`.
