### PR TITLE
ci: migrate to scitex-ai/.github reusable workflows

### DIFF
--- a/.github/workflows/auto-merge-to-develop.yaml
+++ b/.github/workflows/auto-merge-to-develop.yaml
@@ -1,9 +1,9 @@
 name: auto-merge-to-develop
-# Merge green PRs that TARGET develop, the moment their checks complete.
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers/permissions preserved verbatim from the prior local file.
 # GitHub reads check_suite-triggered workflows from the DEFAULT branch (main),
-# so this file lives on main but acts ONLY on PRs whose base is develop.
-# codecov + readthedocs checks are ignored (advisory). Fail-safe: if a merge
-# is blocked by branch policy the PR simply stays open.
+# so this file must stay on main, acting only on PRs whose base is develop
+# (unchanged from before).
 on:
   check_suite:
     types: [completed]
@@ -14,36 +14,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  automerge:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.check_suite.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: merge green PRs targeting develop
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
-        run: |
-          set -uo pipefail
-          if [ -n "${HEAD_SHA:-}" ]; then
-            prs=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[] | select(.state=="open") | .number' 2>/dev/null || true)
-          else
-            prs=$(gh pr list --repo "$REPO" --base develop --state open --json number --jq '.[].number' 2>/dev/null || true)
-          fi
-          [ -z "${prs:-}" ] && { echo "no open PRs"; exit 0; }
-          for pr in $prs; do
-            base=$(gh pr view "$pr" --repo "$REPO" --json baseRefName --jq .baseRefName 2>/dev/null || echo "")
-            [ "$base" = "develop" ] || { echo "skip #$pr (base=$base, not develop)"; continue; }
-            draft=$(gh pr view "$pr" --repo "$REPO" --json isDraft --jq .isDraft 2>/dev/null || echo true)
-            [ "$draft" = "true" ] && continue
-            pending=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq '
-              [ .statusCheckRollup[]
-                | select(((.name // .context // "") | ascii_downcase | test("codecov|readthedocs")) | not)
-                | (.conclusion // .state // "")
-                | select(. != "SUCCESS" and . != "NEUTRAL" and . != "SKIPPED" and . != "") ] | length' 2>/dev/null || echo 1)
-            if [ "$pending" = "0" ]; then
-              gh pr merge "$pr" --repo "$REPO" --merge --admin --delete-branch && echo "MERGED #$pr -> develop" || echo "blocked #$pr"
-            else
-              echo "PR #$pr not green ($pending) — skip"
-            fi
-          done
+  call:
+    uses: scitex-ai/.github/.github/workflows/auto-merge-to-develop.yml@main
+    secrets: inherit

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,5 +1,13 @@
 name: CLA Assistant
 
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers/permissions preserved verbatim from the prior local file.
+# Reusable workflow defaults (owner_login=ywatanabe1989,
+# owner_allowlist="bot*,ywatanabe1989", default_branch=main) already match
+# this repo's prior hardcoded values, so no `with:` overrides are needed.
+# This repo's `GH_PERSONAL_ACCESS_TOKEN` secret already matches the name
+# the reusable workflow expects.
+
 on:
   issue_comment:
     types: [created]
@@ -13,21 +21,6 @@ permissions:
   statuses: write
 
 jobs:
-  CLAssistant:
-    runs-on: ubuntu-latest
-    steps:
-      - name: CLA Assistant
-        uses: contributor-assistant/github-action@v2.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-        with:
-          path-to-signatures: "signatures/cla.json"
-          path-to-document: "https://github.com/ywatanabe1989/scitex-ssh/blob/main/CLA.md"
-          branch: "cla-signatures"
-          allowlist: bot*,ywatanabe1989
-          custom-allsigned-prcomment: |
-            Thank you for signing the SciTeX CLA. Your contribution can now be reviewed.
-          custom-notsigned-prcomment: |
-            Please sign the [SciTeX CLA](https://github.com/ywatanabe1989/scitex-ssh/blob/main/CLA.md) before your contribution can be merged.
-            Comment `I have read and agree to the SciTeX CLA.` to sign.
+  call:
+    uses: scitex-ai/.github/.github/workflows/cla.yml@main
+    secrets: inherit

--- a/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
+++ b/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
@@ -1,11 +1,12 @@
 name: import-smoke
 
-# Catches "wheel installs but `import scitex_ssh` blows up at runtime"
-# — separate from the full pytest suite so a broken entry-point fails
-# fast without paying for the matrix. Companion to `tests` — confirms
-# the bare package (no extras) is `pip install -e .`-able and
-# `import scitex_ssh` succeeds. Catches `[project] dependencies`
-# drift that the test matrix masks because it installs `[all,dev]`.
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers preserved verbatim from the prior local file. The prior local
+# job ran on `ubuntu-latest` with `actions/setup-python` + pip; the reusable
+# workflow instead runs on the self-hosted `spartan-cpu` runner with `uv`
+# (same as the org's canonical CI) — a deliberate infra-standardization,
+# not a functional change to what gets checked
+# (bare `pip install -e .` + `import <pkg>`).
 
 on:
   push:
@@ -17,18 +18,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  install-check:
-    name: import-smoke-on-ubuntu-py3-12
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install (no extras)
-        run: |
-          python -m venv .venv
-          .venv/bin/pip install --upgrade pip
-          .venv/bin/pip install -e .
-      - name: Import smoke
-        run: .venv/bin/python -c "import scitex_ssh; print(scitex_ssh.__version__)"
+  import-smoke:
+    # New required-status-check context: "import-smoke / import-smoke-on-ubuntu-py3-12"
+    uses: scitex-ai/.github/.github/workflows/import-smoke.yml@main
+    secrets: inherit

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -1,5 +1,12 @@
 name: tests
 
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers preserved verbatim from the prior local file. The prior local
+# job ran on `ubuntu-latest` with `actions/setup-python` + pip; the reusable
+# workflow instead runs on the self-hosted `spartan-cpu` runner with `uv`
+# (same as the org's canonical CI) — a deliberate infra-standardization,
+# not a functional change to the pytest suite itself.
+
 on:
   push:
     branches: [main, develop]
@@ -10,33 +17,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    name: pytest-matrix-on-ubuntu-py${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          # Fallback chain: prefer [all,dev] so optional-dep code paths
-          # (yaml, fastmcp, textual) get exercised. Falls back to [dev] then
-          # plain editable so a packaging hiccup doesn't strand CI.
-          pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
-      - name: Run tests
-        run: |
-          pytest tests/ --cov=src/scitex_ssh --cov-report=xml --cov-report=term
-      - name: Upload coverage to Codecov
-        if: always() && matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          fail_ci_if_error: false
+  pytest-matrix:
+    # New required-status-check context: "pytest-matrix / pytest-matrix-on-ubuntu-py<X.YY>"
+    uses: scitex-ai/.github/.github/workflows/pytest-matrix.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What
Part of the fleet-wide CI-workflow content-drift remediation piloted on `scitex-ai/scitex-stats` (PR #69). Converts 4 of this repo's 8 workflow files into thin `workflow_call` callers into reusable workflows hosted at `scitex-ai/.github` (branch `main`):

- `auto-merge-to-develop.yaml` -> `auto-merge-to-develop.yml@main`
- `cla.yml` -> `cla.yml@main` (no overrides needed — secret name and allowlist both already match the reusable workflow's defaults)
- `import-smoke-on-ubuntu-py3-12.yml` -> `import-smoke.yml@main`
- `pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml` -> `pytest-matrix.yml@main`

For `import-smoke`/`pytest-matrix`, the prior local jobs ran on `ubuntu-latest` with pip; the reusable workflows run on this repo's self-hosted `spartan-cpu` runner with `uv`, matching the org's canonical CI. Deliberate infra-standardization, not a functional change to what gets tested.

## Left AS-IS (do not cleanly match a reusable workflow)
- `quality-audit-on-ubuntu-latest.yml`: uses a `--new-only` ratchet (pinned `scitex-dev[cli-audit]>=0.17.14`) to grandfather pre-existing violations. The reusable `quality-audit.yml` has no `--new-only` support — converting would resurface them.
- `rtd-sphinx-build-on-ubuntu-latest.yml` (job name `docs`/`sphinx`): does more than the reusable `rtd-sphinx-build.yml` — it commits the built `_sphinx_html/` bundle back to `develop` on push.
- `newb-docs-quality-on-ubuntu-latest.yml`: no reusable-workflow counterpart in the current 6-workflow catalog.

## Left untouched
- `pypi-publish-and-github-release-on-tag.yml` — PyPI OIDC trusted publishing does not work inside a `workflow_call` reusable workflow (`invalid-publisher` error).

## Branch protection — action needed at merge time
`develop`/`main` currently require `pytest-matrix-on-ubuntu-py3.11/.12/.13`. After merge the actual check contexts become `pytest-matrix / pytest-matrix-on-ubuntu-py3.11` etc. Required-status-checks needs updating in the same change window as merging this PR.

## Do not merge
Left for review — branch protection needs a coordinated update alongside merging.