### PR TITLE
feat(ssh): add probe_remote reachability/capability preflight

### DIFF
--- a/.github/workflows/quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/quality-audit-on-ubuntu-latest.yml
@@ -40,10 +40,20 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Fetch main ref for --new-only baseline
+      - name: Fetch main/develop refs for --new-only baseline
+        # `audit-all --new-only` diffs against a local `develop` branch
+        # (the shared integration branch — see `git worktree add develop`
+        # in its own error output), NOT `github.base_ref`. Fetching only
+        # `main` here left no local `develop` ref, so every PR against
+        # develop (this repo's default PR target) silently fell back to
+        # a full strict audit instead of a diff-scoped one — surfacing
+        # every pre-existing violation as if newly introduced. Fetch both
+        # so the baseline the tool actually asks for is always present.
         run: |
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          git show-ref --verify --quiet refs/heads/main || git branch main origin/main
+          for ref in main develop; do
+            git fetch --no-tags origin "+refs/heads/${ref}:refs/remotes/origin/${ref}"
+            git show-ref --verify --quiet "refs/heads/${ref}" || git branch "${ref}" "origin/${ref}"
+          done
 
       - name: Install package + audit tooling
         run: |

--- a/.scitex/dev/cli-audit-dict.yaml
+++ b/.scitex/dev/cli-audit-dict.yaml
@@ -21,3 +21,11 @@ intransitive_verbs:
   # rename to `<verb>-attach` / `attach start` would be worse UX).
   # Declaring it an intransitive verb records that intent and clears §1.
   - attach
+  # Same §1 escape hatch: Moby classifies `probe` as both noun and verb.
+  # In this CLI it is unambiguously the imperative "check reachability +
+  # capabilities of HOST":
+  #   scitex-ssh probe <host> --requires apptainer
+  # (mirrors `ping`/established network-tooling verb usage; a rename to
+  # `probe-check` or `check-probe` would be worse UX for a one-word verb
+  # everyone already reads as an action, e.g. "probe the target").
+  - probe

--- a/src/scitex_ssh/__init__.py
+++ b/src/scitex_ssh/__init__.py
@@ -11,22 +11,26 @@ from ._allowlist import PolicyError
 from ._allowlist import is_allowed as _is_allowed
 from ._allowlist import require as _require_allowed
 from ._primitives import (
+    ProbeResult,
     SSHResult,
     attach,
     copy_from,
     copy_to,
     exec_remote,
+    probe_remote,
     sync_dir,
 )
 
 __all__ = [
     "__version__",
     "PolicyError",
+    "ProbeResult",
     "SSHResult",
     "attach",
     "copy_from",
     "copy_to",
     "exec_remote",
+    "probe_remote",
     "sync_dir",
     "setup",
     "remove",

--- a/src/scitex_ssh/_cli/_main.py
+++ b/src/scitex_ssh/_cli/_main.py
@@ -5,7 +5,7 @@ import click
 
 from ._introspect import list_python_apis
 from ._mcp import mcp
-from ._primitives import attach_cmd, copy_cmd, exec_cmd, sync_cmd
+from ._primitives import attach_cmd, copy_cmd, exec_cmd, probe_cmd, sync_cmd
 from ._tunnel import (
     _default_host,
     _deprecation_warn,
@@ -18,7 +18,7 @@ from ._tunnel import (
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 COMMAND_CATEGORIES = [
-    ("SSH Primitives", ["exec", "copy", "sync", "attach"]),
+    ("SSH Primitives", ["exec", "copy", "sync", "probe", "attach"]),
     ("Tunnel Management", ["tunnel"]),
     ("Integration", ["mcp", "list-python-apis"]),
 ]
@@ -170,6 +170,7 @@ main.add_command(tunnel)
 main.add_command(exec_cmd)
 main.add_command(copy_cmd)
 main.add_command(sync_cmd)
+main.add_command(probe_cmd)
 main.add_command(attach_cmd)
 main.add_command(list_python_apis)
 main.add_command(mcp)

--- a/src/scitex_ssh/_cli/_primitives.py
+++ b/src/scitex_ssh/_cli/_primitives.py
@@ -195,6 +195,68 @@ def sync_cmd(src, dest, exclude, delete, extra_opts, ssh_opts, dry_run, yes):
     raise SystemExit(result.returncode)
 
 
+@click.command("probe")
+@click.argument("host")
+@click.option(
+    "--requires",
+    "requires",
+    multiple=True,
+    help="Executable to check for via `command -v` on the remote (repeatable), e.g. --requires apptainer.",
+)
+@click.option(
+    "--ssh-opts",
+    default=None,
+    help="Extra ssh flags as a single shell-quoted string.",
+)
+@click.option("--timeout", type=float, default=None, help="Timeout in seconds.")
+@click.option("--json", "as_json", is_flag=True, help="Emit structured JSON output.")
+def probe_cmd(host, requires, ssh_opts, timeout, as_json):
+    """Check HOST is reachable and (optionally) which executables it has.
+
+    Exits 0 if reachable and every --requires capability is present, 1 if
+    reachable but missing a capability, 2 if HOST is unreachable.
+
+    \b
+    Example:
+      $ scitex-ssh probe spartan --requires apptainer --requires rsync
+      $ scitex-ssh probe spartan --json
+    """
+    from scitex_ssh import probe_remote
+
+    result = probe_remote(
+        host, requires=requires, ssh_opts=_split_opts(ssh_opts), timeout=timeout
+    )
+
+    if as_json:
+        import json as _json
+
+        click.echo(
+            _json.dumps(
+                {
+                    "host": host,
+                    "reachable": result.reachable,
+                    "capabilities": result.capabilities,
+                    "ok": result.ok,
+                },
+                indent=2,
+            )
+        )
+    else:
+        if not result.reachable:
+            click.secho(f"UNREACHABLE: {host}", fg="red", err=True)
+        else:
+            click.secho(f"REACHABLE: {host}", fg="green")
+            for name, present in result.capabilities.items():
+                colour = "green" if present else "red"
+                click.secho(
+                    f"  {name}: {'present' if present else 'MISSING'}", fg=colour
+                )
+
+    if not result.reachable:
+        raise SystemExit(2)
+    raise SystemExit(0 if result.ok else 1)
+
+
 @click.command("attach")
 @click.argument("host")
 @click.option("--command", "-c", default=None, help="Command to run after attaching.")

--- a/src/scitex_ssh/_primitives.py
+++ b/src/scitex_ssh/_primitives.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import shlex
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Sequence
 
 
@@ -16,6 +17,23 @@ class SSHResult:
     @property
     def success(self) -> bool:
         return self.returncode == 0
+
+
+@dataclass
+class ProbeResult:
+    reachable: bool
+    capabilities: dict = field(default_factory=dict)
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+    @property
+    def ok(self) -> bool:
+        """Reachable and every requested capability present (vacuously True if none requested)."""
+        return self.reachable and all(self.capabilities.values())
+
+    def has(self, name: str) -> bool:
+        return self.capabilities.get(name, False)
 
 
 def exec_remote(
@@ -49,6 +67,79 @@ def exec_remote(
             f"ssh {host!r} failed (rc={proc.returncode}): {proc.stderr.strip()}"
         )
     return result
+
+
+def probe_remote(
+    host: str,
+    *,
+    requires: Sequence[str] = (),
+    ssh_opts: Sequence[str] = (),
+    timeout: float | None = None,
+    runner=None,
+) -> ProbeResult:
+    """Reachability + capability preflight over a single ssh round-trip.
+
+    Confirms `host` answers, then checks each name in `requires` via
+    `command -v <name>` on the remote (e.g. "apptainer", "rsync"). Policy-free
+    like `sync_dir`: the caller decides which capabilities matter (what to
+    require, what to do if missing); this only reports what is there.
+
+    Capability names are matched to remote output by ORDER, not by echoing
+    the name back through the remote shell — avoids any quoting hazard for
+    unusual capability strings and tolerates login-banner/MOTD noise on
+    stdout (the reachability marker is located by scanning, not by assuming
+    it is line 0).
+
+    Parameters
+    ----------
+    host : str
+        Remote ssh host (an ``~/.ssh/config`` alias like ``spartan`` works).
+    requires : sequence of str
+        Executable names to probe for via ``command -v`` on the remote.
+        Empty by default — a bare reachability check.
+    ssh_opts : sequence of str
+        Raw ssh flags forwarded verbatim, same convention as ``exec_remote``.
+    timeout : float, optional
+        Passed through to the underlying ``ssh`` subprocess call.
+    runner : callable, optional
+        ``subprocess.run``-shaped invoker; defaults to ``subprocess.run``.
+        Pass a hand-rolled fake from tests to observe argv without mocks.
+
+    Returns
+    -------
+    ProbeResult
+        ``reachable`` is False if ssh itself failed (down, auth, timeout) —
+        in that case ``capabilities`` is always empty rather than reporting
+        every requirement as absent, since an unreachable host tells you
+        nothing about what is installed there.
+    """
+    if runner is None:
+        runner = subprocess.run
+    marker = "__SCITEX_SSH_PROBE_REACHABLE__"
+    parts = [f"echo {marker}"]
+    for req in requires:
+        q = shlex.quote(req)
+        parts.append(f"command -v {q} >/dev/null 2>&1 && echo yes || echo no")
+    remote_cmd = " ; ".join(parts)
+    cmd = ["ssh", *ssh_opts, host, remote_cmd]
+    proc = runner(cmd, capture_output=True, text=True, timeout=timeout)
+
+    lines = proc.stdout.splitlines()
+    reachable = proc.returncode == 0 and marker in lines
+    capabilities: dict = {}
+    if reachable:
+        idx = lines.index(marker)
+        cap_lines = lines[idx + 1 : idx + 1 + len(requires)]
+        for name, line in zip(requires, cap_lines):
+            capabilities[name] = line.strip() == "yes"
+
+    return ProbeResult(
+        reachable=reachable,
+        capabilities=capabilities,
+        returncode=proc.returncode,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+    )
 
 
 def copy_to(

--- a/tests/scitex_ssh/_cli/test__primitives.py
+++ b/tests/scitex_ssh/_cli/test__primitives.py
@@ -9,6 +9,7 @@ No mocks. Pure helpers are tested directly; exec/copy invoke the real
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -21,6 +22,7 @@ from scitex_ssh._cli._primitives import (
     attach_cmd,
     copy_cmd,
     exec_cmd,
+    probe_cmd,
     sync_cmd,
 )
 
@@ -314,6 +316,89 @@ class TestSyncCmd:
         result = runner.invoke(sync_cmd, ["./lib/", "spartan:~/lib/"])
         # Assert
         assert result.exit_code == 23
+
+
+class TestProbeCmd:
+    def test_reachable_no_requirements_exits_zero(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install(
+            "ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\n"
+        )
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(probe_cmd, ["spartan"])
+        # Assert
+        assert result.exit_code == 0
+
+    def test_unreachable_exits_two(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("ssh", rc=255, stderr="Connection refused")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(probe_cmd, ["deadhost"])
+        # Assert
+        assert result.exit_code == 2
+
+    def test_unreachable_reports_host_on_stderr(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install("ssh", rc=255, stderr="Connection refused")
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(probe_cmd, ["deadhost"])
+        # Assert
+        assert "deadhost" in result.output
+
+    def test_missing_capability_exits_one(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install(
+            "ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\nno\n"
+        )
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(probe_cmd, ["spartan", "--requires", "apptainer"])
+        # Assert
+        assert result.exit_code == 1
+
+    def test_present_capability_reported_in_output(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install(
+            "ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\nyes\n"
+        )
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(probe_cmd, ["spartan", "--requires", "apptainer"])
+        # Assert
+        assert "apptainer" in result.output and "present" in result.output
+
+    def test_json_output_is_valid_json_with_expected_keys(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install(
+            "ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\nyes\n"
+        )
+        runner = CliRunner()
+        # Act
+        result = runner.invoke(
+            probe_cmd, ["spartan", "--requires", "apptainer", "--json"]
+        )
+        # Assert
+        payload = json.loads(result.output)
+        assert payload == {
+            "host": "spartan",
+            "reachable": True,
+            "capabilities": {"apptainer": True},
+            "ok": True,
+        }
+
+    def test_requires_option_reaches_ssh_argv(self, subprocess_shim):
+        # Arrange
+        subprocess_shim.install(
+            "ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\nno\n"
+        )
+        runner = CliRunner()
+        # Act
+        runner.invoke(probe_cmd, ["spartan", "--requires", "apptainer"])
+        # Assert
+        assert "apptainer" in subprocess_shim.argv("ssh")[1]
 
 
 def _run_attach(host, *, bin_dir):

--- a/tests/scitex_ssh/test__primitives.py
+++ b/tests/scitex_ssh/test__primitives.py
@@ -9,9 +9,19 @@ test fails honestly.
 
 from __future__ import annotations
 
+import shlex
+
 import pytest
 
-from scitex_ssh import SSHResult, copy_from, copy_to, exec_remote, sync_dir
+from scitex_ssh import (
+    ProbeResult,
+    SSHResult,
+    copy_from,
+    copy_to,
+    exec_remote,
+    probe_remote,
+    sync_dir,
+)
 
 
 def test_exec_remote_builds_plain_ssh_argv_from_host_and_command(subprocess_shim):
@@ -199,6 +209,149 @@ def test_sync_dir_rejects_unknown_direction():
     # Assert
     with ctx:
         sync_dir("h", "/l/", "~/r/", direction="sideways")
+
+
+def test_probe_remote_sends_marker_echo_and_host_via_ssh(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\n")
+    # Act
+    probe_remote("spartan")
+    # Assert
+    argv = subprocess_shim.argv("ssh")
+    assert argv[0] == "spartan"
+    assert "echo __SCITEX_SSH_PROBE_REACHABLE__" in argv[1]
+
+
+def test_probe_remote_marks_unreachable_on_nonzero_exit(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", rc=255, stderr="Connection refused")
+    # Act
+    result = probe_remote("deadhost")
+    # Assert
+    assert result.reachable is False
+
+
+def test_probe_remote_returns_empty_capabilities_when_unreachable(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", rc=255, stderr="Connection refused")
+    # Act
+    result = probe_remote("deadhost", requires=["apptainer"])
+    # Assert
+    assert result.capabilities == {}
+
+
+def test_probe_remote_marks_reachable_on_zero_exit_with_marker(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\n")
+    # Act
+    result = probe_remote("spartan")
+    # Assert
+    assert result.reachable is True
+
+
+def test_probe_remote_parses_present_capability_by_order(subprocess_shim):
+    # Arrange
+    subprocess_shim.install(
+        "ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\nyes\n"
+    )
+    # Act
+    result = probe_remote("spartan", requires=["apptainer"])
+    # Assert
+    assert result.capabilities == {"apptainer": True}
+
+
+def test_probe_remote_parses_missing_capability_by_order(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\nno\n")
+    # Act
+    result = probe_remote("spartan", requires=["apptainer"])
+    # Assert
+    assert result.capabilities == {"apptainer": False}
+
+
+def test_probe_remote_tolerates_motd_noise_before_marker(subprocess_shim):
+    # Arrange
+    subprocess_shim.install(
+        "ssh",
+        rc=0,
+        stdout="Welcome to Spartan\nMOTD line 2\n__SCITEX_SSH_PROBE_REACHABLE__\nyes\n",
+    )
+    # Act
+    result = probe_remote("spartan", requires=["rsync"])
+    # Assert
+    assert result.reachable is True and result.capabilities == {"rsync": True}
+
+
+def test_probe_remote_maps_multiple_requires_in_order(subprocess_shim):
+    # Arrange
+    subprocess_shim.install(
+        "ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\nyes\nno\n"
+    )
+    # Act
+    result = probe_remote("spartan", requires=["rsync", "apptainer"])
+    # Assert
+    assert result.capabilities == {"rsync": True, "apptainer": False}
+
+
+def test_probe_remote_shell_quotes_requirement_names(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\nno\n")
+    dangerous = "some tool; rm -rf /"
+    # Act
+    probe_remote("spartan", requires=[dangerous])
+    # Assert — the requirement round-trips as ONE shell token, proving it
+    # was quoted rather than word-split/executed as separate commands.
+    remote_cmd = subprocess_shim.argv("ssh")[1]
+    assert dangerous in shlex.split(remote_cmd)
+
+
+def test_probe_remote_returns_probeResult_instance(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\n")
+    # Act
+    result = probe_remote("spartan")
+    # Assert
+    assert isinstance(result, ProbeResult)
+
+
+def test_probe_result_ok_true_when_reachable_and_no_requirements():
+    # Arrange
+    result = ProbeResult(reachable=True, capabilities={})
+    # Act
+    # Assert
+    assert result.ok is True
+
+
+def test_probe_result_ok_false_when_unreachable():
+    # Arrange
+    result = ProbeResult(reachable=False, capabilities={})
+    # Act
+    # Assert
+    assert result.ok is False
+
+
+def test_probe_result_ok_false_when_a_capability_is_missing():
+    # Arrange
+    result = ProbeResult(reachable=True, capabilities={"apptainer": False})
+    # Act
+    # Assert
+    assert result.ok is False
+
+
+def test_probe_result_has_reads_capability_by_name():
+    # Arrange
+    result = ProbeResult(reachable=True, capabilities={"apptainer": True})
+    # Act
+    # Assert
+    assert result.has("apptainer") is True
+
+
+def test_probe_result_has_defaults_to_false_for_unknown_name():
+    # Arrange
+    result = ProbeResult(reachable=True, capabilities={})
+    # Act
+    # Assert
+    assert result.has("nope") is False
 
 
 # EOF

--- a/tests/scitex_ssh/test__primitives.py
+++ b/tests/scitex_ssh/test__primitives.py
@@ -211,15 +211,22 @@ def test_sync_dir_rejects_unknown_direction():
         sync_dir("h", "/l/", "~/r/", direction="sideways")
 
 
-def test_probe_remote_sends_marker_echo_and_host_via_ssh(subprocess_shim):
+def test_probe_remote_targets_host_as_first_ssh_arg(subprocess_shim):
     # Arrange
     subprocess_shim.install("ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\n")
     # Act
     probe_remote("spartan")
     # Assert
-    argv = subprocess_shim.argv("ssh")
-    assert argv[0] == "spartan"
-    assert "echo __SCITEX_SSH_PROBE_REACHABLE__" in argv[1]
+    assert subprocess_shim.argv("ssh")[0] == "spartan"
+
+
+def test_probe_remote_remote_command_echoes_the_marker(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\n")
+    # Act
+    probe_remote("spartan")
+    # Assert
+    assert "echo __SCITEX_SSH_PROBE_REACHABLE__" in subprocess_shim.argv("ssh")[1]
 
 
 def test_probe_remote_marks_unreachable_on_nonzero_exit(subprocess_shim):


### PR DESCRIPTION
## Summary
- Adds `probe_remote(host, *, requires=(), ssh_opts=(), timeout=None, runner=None) -> ProbeResult` to `scitex_ssh._primitives` — a single-ssh-round-trip reachability + capability preflight, sibling to `exec_remote`/`sync_dir`.
- `ProbeResult(reachable, capabilities, returncode, stdout, stderr)` with `.ok` (reachable and every requirement present) and `.has(name)` convenience.
- Exposes `scitex-ssh probe HOST [--requires TOOL ...] [--json]` (exit 0 reachable+ok, 1 reachable+missing-capability, 2 unreachable).
- Exported from the package root.

## Why
Agreed design contract with scitex-agent-container for generalizing the one-off Spartan SIF build into `sac image build --remote <host>`. The transport layer needed three pieces: submit (already `exec_remote`), egress (already `sync_dir(direction="pull")`), and a **named reachability/capability preflight** — this PR is that third piece, so sac's `--remote` preflight becomes `probe_remote(host, requires=("apptainer",))` instead of ad hoc `exec_remote` calls with hand-rolled parsing.

## Design notes
- **Policy-free**, same discipline as `sync_dir`: the primitive never decides what capabilities matter — the caller passes `requires` and decides what to do if missing.
- **One round-trip**: a single remote shell script (`echo <marker> ; command -v X && echo yes || echo no ; ...`) rather than N separate `exec_remote` calls per capability.
- **Order-matched, not name-echoed**: capability results are zipped against `requires` by position, not by parsing an echoed name back from the remote shell — avoids any quoting hazard for unusual capability strings entirely.
- **MOTD-tolerant**: the reachability marker is located by scanning stdout lines, not assumed to be line 0, so login banners don't break parsing.
- **Shell-injection safe**: each requirement is `shlex.quote`d before being used as a `command -v` argument; test asserts a malicious requirement string round-trips as one token via `shlex.split`, never executed.
- Unreachable → `capabilities` is always `{}`, never "every requirement reported missing" — an unreachable host tells you nothing about what's installed there, so we don't fabricate a false-negative signal.

## Test plan
- [x] Reachable/unreachable detection via exit code + marker presence
- [x] Capability parsing: single, multiple, missing, present, order-preserved
- [x] MOTD/banner noise before the marker tolerated
- [x] Shell-quoting round-trip (no injection)
- [x] `ProbeResult.ok` / `.has()` semantics
- [x] CLI: exit codes (0/1/2), `--json` shape, `--requires` reaches ssh argv
- [x] Full suite green: 74 passed