### PR TITLE
fix(ssh): default automation calls to no-multiplex, no-forward ssh transport

### DIFF
--- a/src/scitex_ssh/_primitives.py
+++ b/src/scitex_ssh/_primitives.py
@@ -19,6 +19,51 @@ class SSHResult:
         return self.returncode == 0
 
 
+_SAFE_TRANSPORT_DEFAULTS = {
+    "controlmaster": "ControlMaster=no",
+    "controlpath": "ControlPath=none",
+    "clearallforwardings": "ClearAllForwardings=yes",
+}
+
+
+def _with_safe_transport_defaults(ssh_opts: Sequence[str]) -> list[str]:
+    """Prepend safe-for-automation ssh defaults unless the caller already set them.
+
+    exec_remote/sync_dir/probe_remote/copy_to/copy_from are one-shot
+    automation calls, not interactive sessions — they should never
+    silently inherit a host's interactive-session baggage:
+
+    * ControlMaster multiplexing assumes a writable ``~/.ssh/`` for the
+      control socket. Containers commonly mount it read-only for NEW
+      sockets while leaving pre-existing ones live, which makes failures
+      look host-specific ("this alias works, that one doesn't") when it
+      is really just "which socket file happened to already exist."
+    * Local/RemoteForward entries in ``~/.ssh/config`` are typically
+      scoped to one human's single interactive session (a relay, an
+      audio forward, a reverse tunnel). Concurrent automated callers all
+      hitting the same alias will port-conflict on those fixed ports.
+
+    Both default off. A caller who deliberately wants multiplexing or
+    config-level forwards can still opt in by passing their own
+    ``-o ControlMaster=...`` / ``-o ControlPath=...`` / ``-o
+    ClearAllForwardings=no`` in ``ssh_opts`` — this only fills in keys
+    the caller did not already set. ``attach`` (an interactive session
+    by design) is deliberately NOT covered by this — a human attaching
+    to a host benefits from the same multiplexing/forwards that make
+    them risky for concurrent automation.
+    """
+    already_set = {
+        ssh_opts[i + 1].split("=", 1)[0].strip().lower()
+        for i in range(len(ssh_opts) - 1)
+        if ssh_opts[i] == "-o"
+    }
+    defaults: list[str] = []
+    for key, opt in _SAFE_TRANSPORT_DEFAULTS.items():
+        if key not in already_set:
+            defaults += ["-o", opt]
+    return [*defaults, *ssh_opts]
+
+
 @dataclass
 class ProbeResult:
     reachable: bool
@@ -49,6 +94,9 @@ def exec_remote(
 
     `ssh_opts` is a list of raw ssh flags (e.g. ['-A', '-o', 'StrictHostKeyChecking=no'])
     passed through verbatim. Users opt into agent forwarding by passing '-A' themselves.
+    Defaults to `-o ControlMaster=no -o ControlPath=none -o ClearAllForwardings=yes`
+    (see `_with_safe_transport_defaults`) unless `ssh_opts` already sets one of those
+    keys — a one-shot call shouldn't inherit multiplexing or ambient config forwards.
 
     Parameters
     ----------
@@ -59,7 +107,7 @@ def exec_remote(
     """
     if runner is None:
         runner = subprocess.run
-    cmd = ["ssh", *ssh_opts, host, command]
+    cmd = ["ssh", *_with_safe_transport_defaults(ssh_opts), host, command]
     proc = runner(cmd, capture_output=True, text=True, timeout=timeout)
     result = SSHResult(proc.returncode, proc.stdout, proc.stderr)
     if check and not result.success:
@@ -98,7 +146,9 @@ def probe_remote(
         Executable names to probe for via ``command -v`` on the remote.
         Empty by default — a bare reachability check.
     ssh_opts : sequence of str
-        Raw ssh flags forwarded verbatim, same convention as ``exec_remote``.
+        Raw ssh flags forwarded verbatim, same convention as ``exec_remote``
+        (including the same safe-by-default ControlMaster/ClearAllForwardings
+        behavior — see ``_with_safe_transport_defaults``).
     timeout : float, optional
         Passed through to the underlying ``ssh`` subprocess call.
     runner : callable, optional
@@ -121,7 +171,7 @@ def probe_remote(
         q = shlex.quote(req)
         parts.append(f"command -v {q} >/dev/null 2>&1 && echo yes || echo no")
     remote_cmd = " ; ".join(parts)
-    cmd = ["ssh", *ssh_opts, host, remote_cmd]
+    cmd = ["ssh", *_with_safe_transport_defaults(ssh_opts), host, remote_cmd]
     proc = runner(cmd, capture_output=True, text=True, timeout=timeout)
 
     lines = proc.stdout.splitlines()
@@ -151,13 +201,14 @@ def copy_to(
     ssh_opts: Sequence[str] = (),
     runner=None,
 ) -> SSHResult:
-    """scp local `src` to `host:dest`. ssh_opts forwarded via -o."""
+    """scp local `src` to `host:dest`. ssh_opts forwarded via -o (same
+    safe-by-default ControlMaster/ClearAllForwardings behavior as exec_remote)."""
     if runner is None:
         runner = subprocess.run
     cmd = [
         "scp",
         *(["-r"] if recursive else []),
-        *_ssh_opts_to_scp(ssh_opts),
+        *_ssh_opts_to_scp(_with_safe_transport_defaults(ssh_opts)),
         src,
         f"{host}:{dest}",
     ]
@@ -174,13 +225,13 @@ def copy_from(
     ssh_opts: Sequence[str] = (),
     runner=None,
 ) -> SSHResult:
-    """scp `host:src` to local `dest`."""
+    """scp `host:src` to local `dest`. Same safe-by-default ssh_opts as copy_to."""
     if runner is None:
         runner = subprocess.run
     cmd = [
         "scp",
         *(["-r"] if recursive else []),
-        *_ssh_opts_to_scp(ssh_opts),
+        *_ssh_opts_to_scp(_with_safe_transport_defaults(ssh_opts)),
         f"{host}:{src}",
         dest,
     ]
@@ -240,7 +291,11 @@ def sync_dir(
         ``--checksum``, ``--mkpath``, ``--dry-run``, ``--info=progress2``).
     ssh_opts : sequence of str
         ssh flags for the transport; wired via ``-e 'ssh <opts>'`` (e.g.
-        ``['-o', 'BatchMode=yes']`` for non-interactive cron).
+        ``['-o', 'BatchMode=yes']`` for non-interactive cron). Always includes
+        the same safe-by-default ControlMaster/ClearAllForwardings behavior as
+        ``exec_remote`` (see ``_with_safe_transport_defaults``) — a plain rsync
+        transport shouldn't inherit multiplexing or ambient config forwards
+        either.
     runner : callable, optional
         ``subprocess.run``-shaped invoker; defaults to ``subprocess.run``.
         Pass a hand-rolled fake from tests to observe argv without mocks.
@@ -263,7 +318,8 @@ def sync_dir(
         *(["--delete"] if delete else []),
         *extra_opts,
         *[f"--exclude={pat}" for pat in exclude],
-        *(["-e", "ssh " + " ".join(ssh_opts)] if ssh_opts else []),
+        "-e",
+        "ssh " + " ".join(_with_safe_transport_defaults(ssh_opts)),
         src,
         dest,
     ]

--- a/tests/scitex_ssh/_cli/test__primitives.py
+++ b/tests/scitex_ssh/_cli/test__primitives.py
@@ -235,8 +235,9 @@ class TestCopyCmd:
         runner = CliRunner()
         # Act
         runner.invoke(copy_cmd, ["myhost:/etc/hostname", "./hostname"])
-        # Assert
-        assert subprocess_shim.argv("scp") == ["myhost:/etc/hostname", "./hostname"]
+        # Assert — src/dest are always the last two argv elements, robust
+        # to the safe-transport-defaults prefix scitex_ssh adds by default.
+        assert subprocess_shim.argv("scp")[-2:] == ["myhost:/etc/hostname", "./hostname"]
 
 
 class TestSyncCmd:
@@ -398,7 +399,7 @@ class TestProbeCmd:
         # Act
         runner.invoke(probe_cmd, ["spartan", "--requires", "apptainer"])
         # Assert
-        assert "apptainer" in subprocess_shim.argv("ssh")[1]
+        assert "apptainer" in subprocess_shim.argv("ssh")[-1]
 
 
 def _run_attach(host, *, bin_dir):

--- a/tests/scitex_ssh/test__primitives.py
+++ b/tests/scitex_ssh/test__primitives.py
@@ -24,13 +24,27 @@ from scitex_ssh import (
 )
 
 
+SAFE_TRANSPORT_DEFAULTS = [
+    "-o",
+    "ControlMaster=no",
+    "-o",
+    "ControlPath=none",
+    "-o",
+    "ClearAllForwardings=yes",
+]
+
+
 def test_exec_remote_builds_plain_ssh_argv_from_host_and_command(subprocess_shim):
     # Arrange
     subprocess_shim.install("ssh", rc=0, stdout="hi")
     # Act
     exec_remote("spartan", "hostname")
     # Assert
-    assert subprocess_shim.argv("ssh") == ["spartan", "hostname"]
+    assert subprocess_shim.argv("ssh") == [
+        *SAFE_TRANSPORT_DEFAULTS,
+        "spartan",
+        "hostname",
+    ]
 
 
 def test_exec_remote_returns_sshresult_instance(subprocess_shim):
@@ -65,14 +79,26 @@ def test_exec_remote_passes_ssh_opts_through_verbatim(subprocess_shim):
     subprocess_shim.install("ssh", rc=0)
     # Act
     exec_remote("h", "cmd", ssh_opts=["-A", "-o", "StrictHostKeyChecking=no"])
-    # Assert
+    # Assert — caller opts are appended after the safe transport defaults,
+    # since neither sets ControlMaster/ControlPath/ClearAllForwardings.
     assert subprocess_shim.argv("ssh") == [
+        *SAFE_TRANSPORT_DEFAULTS,
         "-A",
         "-o",
         "StrictHostKeyChecking=no",
         "h",
         "cmd",
     ]
+
+
+def test_exec_remote_respects_caller_controlmaster_override(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", rc=0)
+    # Act
+    exec_remote("h", "cmd", ssh_opts=["-o", "ControlMaster=auto"])
+    # Assert — caller's explicit ControlMaster is kept, ours is not added
+    argv = subprocess_shim.argv("ssh")
+    assert argv.count("ControlMaster=auto") == 1 and "ControlMaster=no" not in argv
 
 
 def test_exec_remote_raises_runtimeerror_when_check_and_nonzero_exit(subprocess_shim):
@@ -96,9 +122,11 @@ def test_copy_to_recursive_drops_basic_flags_and_keeps_o_and_i_opts(subprocess_s
         recursive=True,
         ssh_opts=["-A", "-o", "K=V", "-i", "/key"],
     )
-    # Assert — -A dropped (not relevant for scp); -o K=V and -i /key kept
+    # Assert — -A dropped (not relevant for scp); safe defaults prepended
+    # (all -o pairs, so they survive the scp filter); -o K=V and -i /key kept
     assert subprocess_shim.argv("scp") == [
         "-r",
+        *SAFE_TRANSPORT_DEFAULTS,
         "-o",
         "K=V",
         "-i",
@@ -114,7 +142,11 @@ def test_copy_from_constructs_remote_source_argv(subprocess_shim):
     # Act
     copy_from("h", "~/src", "/local/dest")
     # Assert
-    assert subprocess_shim.argv("scp") == ["h:~/src", "/local/dest"]
+    assert subprocess_shim.argv("scp") == [
+        *SAFE_TRANSPORT_DEFAULTS,
+        "h:~/src",
+        "/local/dest",
+    ]
 
 
 def test_sync_dir_push_puts_remote_dest_last(subprocess_shim):
@@ -126,6 +158,8 @@ def test_sync_dir_push_puts_remote_dest_last(subprocess_shim):
     assert subprocess_shim.argv("rsync") == [
         "-a",
         "--partial",
+        "-e",
+        "ssh " + " ".join(SAFE_TRANSPORT_DEFAULTS),
         "/local/lib/",
         "spartan:~/lib/",
     ]
@@ -140,6 +174,8 @@ def test_sync_dir_pull_puts_remote_src_first(subprocess_shim):
     assert subprocess_shim.argv("rsync") == [
         "-a",
         "--partial",
+        "-e",
+        "ssh " + " ".join(SAFE_TRANSPORT_DEFAULTS),
         "spartan:~/lib/",
         "/local/lib/",
     ]
@@ -178,9 +214,19 @@ def test_sync_dir_wires_ssh_opts_into_e_flag(subprocess_shim):
     subprocess_shim.install("rsync", rc=0)
     # Act
     sync_dir("h", "/l/", "~/r/", ssh_opts=["-o", "BatchMode=yes"])
-    # Assert
+    # Assert — caller ssh_opts appended after the safe transport defaults
     argv = subprocess_shim.argv("rsync")
-    assert argv[argv.index("-e") + 1] == "ssh -o BatchMode=yes"
+    expected = "ssh " + " ".join([*SAFE_TRANSPORT_DEFAULTS, "-o", "BatchMode=yes"])
+    assert argv[argv.index("-e") + 1] == expected
+
+
+def test_sync_dir_always_passes_e_flag_even_with_no_caller_ssh_opts(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("rsync", rc=0)
+    # Act
+    sync_dir("h", "/l/", "~/r/")
+    # Assert — the safe defaults mean -e is never omitted, unlike before
+    assert "-e" in subprocess_shim.argv("rsync")
 
 
 def test_sync_dir_appends_extra_opts_verbatim(subprocess_shim):
@@ -211,13 +257,13 @@ def test_sync_dir_rejects_unknown_direction():
         sync_dir("h", "/l/", "~/r/", direction="sideways")
 
 
-def test_probe_remote_targets_host_as_first_ssh_arg(subprocess_shim):
-    # Arrange
+def test_probe_remote_targets_host_as_second_to_last_ssh_arg(subprocess_shim):
+    # Arrange — safe transport defaults precede host/remote_cmd now
     subprocess_shim.install("ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\n")
     # Act
     probe_remote("spartan")
     # Assert
-    assert subprocess_shim.argv("ssh")[0] == "spartan"
+    assert subprocess_shim.argv("ssh")[-2] == "spartan"
 
 
 def test_probe_remote_remote_command_echoes_the_marker(subprocess_shim):
@@ -226,7 +272,17 @@ def test_probe_remote_remote_command_echoes_the_marker(subprocess_shim):
     # Act
     probe_remote("spartan")
     # Assert
-    assert "echo __SCITEX_SSH_PROBE_REACHABLE__" in subprocess_shim.argv("ssh")[1]
+    assert "echo __SCITEX_SSH_PROBE_REACHABLE__" in subprocess_shim.argv("ssh")[-1]
+
+
+def test_probe_remote_includes_safe_transport_defaults(subprocess_shim):
+    # Arrange
+    subprocess_shim.install("ssh", rc=0, stdout="__SCITEX_SSH_PROBE_REACHABLE__\n")
+    # Act
+    probe_remote("spartan")
+    # Assert
+    argv = subprocess_shim.argv("ssh")
+    assert argv[: len(SAFE_TRANSPORT_DEFAULTS)] == SAFE_TRANSPORT_DEFAULTS
 
 
 def test_probe_remote_marks_unreachable_on_nonzero_exit(subprocess_shim):
@@ -308,7 +364,7 @@ def test_probe_remote_shell_quotes_requirement_names(subprocess_shim):
     probe_remote("spartan", requires=[dangerous])
     # Assert — the requirement round-trips as ONE shell token, proving it
     # was quoted rather than word-split/executed as separate commands.
-    remote_cmd = subprocess_shim.argv("ssh")[1]
+    remote_cmd = subprocess_shim.argv("ssh")[-1]
     assert dangerous in shlex.split(remote_cmd)
 
 


### PR DESCRIPTION
## Summary
`exec_remote`, `probe_remote`, `copy_to`, `copy_from`, and `sync_dir` now default every ssh/scp/rsync invocation to:

```
-o ControlMaster=no -o ControlPath=none -o ClearAllForwardings=yes
```

...unless the caller's `ssh_opts` already sets `ControlMaster`/`ControlPath` explicitly (so anyone who deliberately wants multiplexing can still opt in). `attach()` (interactive by design) and the persistent autossh tunnel daemon (`_tunnel_render.py`) are untouched — both are long-lived, single-purpose connections where multiplexing/forwards are the point, not a hazard.

## Why
scitex-storage hit this while smoke-testing `archive`/`restore` (built on `sync_dir`) against the `nas` alias from inside a container:

1. **ControlMaster socket-bind failures.** A container's `~/.ssh/` is often read-only for *new* control-socket files, but pre-existing sockets from earlier sessions get silently reused — so results look host-specific ("this alias works, that one doesn't") when it's really just "which socket file happened to already exist" in that particular container. Reproduced this myself independently in a different container with the opposite flip (nas worked, nas2 didn't) — same root cause, different socket-existence luck.
2. **Hardcoded port-forward conflicts.** `nas`'s `~/.ssh/config` block carries `LocalForward`/`RemoteForward` entries (a relay, an audio forward, a reverse tunnel) scoped to one human's interactive session. Concurrent automated callers hitting the same alias port-conflict on those fixed ports, independent of ControlMaster.

Neither is something a one-shot automation primitive should silently inherit — multiplexing and config-level forwards are conveniences for a *repeated human session*, not something a single automated call needs or benefits from. Callers who deliberately want either can still opt in via their own `ssh_opts`.

## Test plan
- [x] Every existing argv-assertion test updated for the new prefix (or switched to a `[-2:]`/`[-1]` suffix check where the prefix-position was incidental to the test, e.g. sync_cmd's dest-argv check already did this)
- [x] New test confirming a caller's explicit `ControlMaster=...` override is respected, not clobbered
- [x] `sync_dir` now always includes `-e` (previously omitted when caller `ssh_opts` was empty) — added a regression test for that
- [x] Full suite green: 274 passed, 1 skipped