### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-12
+
+### Added
+
+- `probe_remote()` primitive: single-ssh-round-trip reachability +
+  capability preflight (`command -v <name>` checks), policy-free like
+  `sync_dir`. Exposed as `scitex-ssh probe HOST [--requires TOOL ...]
+  [--json]`.
+- `tunnel render-argv` — pure `ssh -L`/`-R` argv renderer (no side
+  effects), for callers that want the exact tunnel command without
+  invoking it.
+- `tunnel forward --discovery` — discovery-driven forward tunnel setup.
+
+### Changed
+
+- **`exec_remote`/`probe_remote`/`copy_to`/`copy_from`/`sync_dir` now
+  default every ssh/scp/rsync invocation to `-o ControlMaster=no -o
+  ControlPath=none -o ClearAllForwardings=yes`**, unless the caller's
+  `ssh_opts` already sets `ControlMaster`/`ControlPath` explicitly.
+  These are one-shot automation calls, not interactive sessions, and
+  should not silently inherit a host's interactive-session baggage:
+  ControlMaster multiplexing assumes a writable `~/.ssh/` for the
+  control socket (containers often mount it read-only for *new*
+  sockets while reusing pre-existing ones, which made failures look
+  host-specific when they were really just "which socket already
+  existed"), and `Local`/`RemoteForward` entries in `~/.ssh/config` are
+  typically scoped to one human's session — concurrent automated
+  callers hitting the same alias will port-conflict on fixed ports
+  regardless of ControlMaster. A caller who deliberately wants either
+  can still opt in via their own `ssh_opts`. `attach()` (interactive by
+  design) and the persistent autossh tunnel daemon are unaffected.
+  `sync_dir` now always passes `-e` to rsync (previously omitted when
+  `ssh_opts` was empty).
+- Reverse autossh tunnel unit hardened against a dead-forward-after-blip
+  failure mode: adds `ServerAliveInterval`/`ServerAliveCountMax`/
+  `ExitOnForwardFailure` so a network blip doesn't leave the forward
+  silently dead while systemd reports the unit as running.
+
 ## [1.1.0] - 2026-07-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-ssh"
-version = "1.1.0"
+version = "1.2.0"
 description = "SSH primitives for SciTeX (exec/copy/attach/tunnel; per-host allowlist)"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump 1.1.0 -> 1.2.0 and CHANGELOG covering everything merged to develop since the last release: probe_remote, tunnel render-argv, tunnel forward --discovery, the hardened reverse-tunnel autossh unit, and the safe-ssh-transport-defaults fix (PR #54). Tag v1.2.0 follows once this merges; the tag pipeline publishes to PyPI and syncs main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)