### PR TITLE
ci: run pytest on Spartan, not GitHub-hosted runners

### DIFF
--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -1,5 +1,12 @@
 name: tests
 
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers preserved verbatim from the prior local file. The prior local
+# job ran on `ubuntu-latest` with `actions/setup-python` + pip; the reusable
+# workflow instead runs on the self-hosted `spartan-cpu` runner with `uv`
+# (same as the org's canonical CI) — a deliberate infra-standardization,
+# not a functional change to the pytest suite itself.
+
 on:
   push:
     branches: [main, develop]
@@ -10,33 +17,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    name: pytest-matrix-on-ubuntu-py${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          # Fallback chain: prefer [all,dev] so optional-dep code paths
-          # (yaml, fastmcp, textual) get exercised. Falls back to [dev] then
-          # plain editable so a packaging hiccup doesn't strand CI.
-          pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
-      - name: Run tests
-        run: |
-          pytest tests/ --cov=src/scitex_ssh --cov-report=xml --cov-report=term
-      - name: Upload coverage to Codecov
-        if: always() && matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          fail_ci_if_error: false
+  pytest-matrix:
+    # New required-status-check context: "pytest-matrix / pytest-matrix-on-ubuntu-py<X.YY>"
+    uses: scitex-ai/.github/.github/workflows/pytest-matrix.yml@main
+    secrets: inherit


### PR DESCRIPTION
Promotes develop's already-migrated pytest workflow (a thin caller of the org reusable `pytest-matrix`, which pins `runs-on: [self-hosted, Linux, X64, spartan-cpu]`) onto `main`, which still ran on `ubuntu-latest`.

Piloted first, one repo per class, both green on Spartan:
- **scitex-dict#24** — protection still carried the pre-migration (bare) check names, so it had to be reconciled to the emitted `pytest-matrix / ...` names in the same change. Every check was green with `mergeStateStatus: BLOCKED` until then.
- **scitex-os#29** — protection *already* required the post-migration names, so no protection change was needed; the promotion actually **repaired** a repo whose main PRs could never satisfy their required checks.

Which case this repo is was determined by reading its actual protection and the names this PR actually emits — not by assuming. Context: the org runner pool now dispatches (it previously excluded public repos silently, so jobs queued forever with no error).