### PR TITLE
fix(envrc): direnv pointed this repo at a card store that no longer exists

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,23 @@
 
-export SCITEX_TODO_AGENT_ID="scitex-tunnel"
-export SCITEX_TODO_TASKS_YAML_SHARED="$HOME/.scitex/todo/tasks.yaml"
+# Board identity for this repo's agent.
+#
+# The card store is a SQLite DB, and has been since the 2026-07-16
+# scitex-todo -> scitex-cards cutover. This file previously exported:
+#
+#   SCITEX_TODO_TASKS_YAML_SHARED="$HOME/.scitex/todo/tasks.yaml"
+#
+# and that file NO LONGER EXISTS. That is not a cosmetic rename miss: an
+# explicit store path WINS the resolution chain, so direnv silently handed
+# anyone working in this repo a store that cannot be read or written. The
+# failure presents as "the board is empty", never as an error, which is why it
+# survives unnoticed — the identical shape caused a real, hours-long silent
+# MCP write outage in scitex-cards on 2026-07-19.
+#
+# Only the CANONICAL names are set here. The legacy SCITEX_TODO_* aliases are
+# NOT written by hand: scitex_cards._env_compat.mirror_env already copies every
+# SCITEX_CARDS_* key into its SCITEX_TODO_* twin at import. Writing both would
+# add a second place for the pair to disagree, and a store whose two names
+# resolve to different files is precisely what took the live board down.
+export SCITEX_CARDS_AGENT_ID="scitex-tunnel"
+export SCITEX_CARDS_STORE_BACKEND="sqlite"
+export SCITEX_CARDS_DB="$HOME/.scitex/cards/cards.db"


### PR DESCRIPTION
This repo's `.envrc` exported

```
SCITEX_TODO_TASKS_YAML_SHARED="$HOME/.scitex/todo/tasks.yaml"
```

and **that path is gone** — the card store became a SQLite DB at the `scitex-todo` → `scitex-cards` cutover (2026-07-16) and the YAML was retired.

### Why this is not a cosmetic rename miss

An explicit store path **wins** the resolution chain. So direnv silently handed anyone working in this repo a store that cannot be read or written. It presents as *"the board is empty"*, never as an error — which is exactly why it survives unnoticed.

The identical shape caused a real, hours-long **silent MCP write outage** in scitex-cards earlier the same day.

### How it was found

Surveyed all 66 ecosystem repos:

```
scitex-dev ecosystem bulk --yes -- cat ~/proj/{}/.envrc
```

Two repos still named the dead path: this one, and the `scitex-todo` checkout (same git repo as scitex-cards, so that one is fixed by its own PR).

### What it sets now

Only the **canonical** names. The legacy `SCITEX_TODO_*` aliases are deliberately **not** written by hand — `scitex_cards._env_compat.mirror_env` already copies every `SCITEX_CARDS_*` key into its `SCITEX_TODO_*` twin at import. Writing both would add a second place for the pair to disagree, and a store whose two names resolve to different files is what took the board down.